### PR TITLE
fix: wrong MCP acronym in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ From simple chatbots and MCP examples to advance AI Agents, this repository serv
 
 ## 🗂️ MCP Agents
 
-**Examples using Managed Compute Providers:**
+**Examples using Model Context Protocol:**
 
 * [Doc-MCP](mcp_ai_agents/doc_mcp) - Semantic RAG docs & Q\&A.
 * [LangGraph MCP Agent](mcp_ai_agents/langchain_langgraph_mcp_agent) - LangChain ReAct agent with Couchbase.


### PR DESCRIPTION
# Pull Request

## Type of Change

- [ ] Project Addition
- [ ] Bug Fix
- [ ] Feature Implementation
- [x] Documentation Update
- [ ] Other (please describe)

## Project Details

- Project Name: N/A
- Target Directory: N/A

## Description

Corrected the MCP section description in `README.md` from “Managed Compute Providers” to “Model Context Protocol”.

## Technical Details

- Primary Language/Framework: Markdown
- Key Dependencies: None
- API Requirements: None
- Changes to existing code: None — documentation only
- New files added: None
- Dependencies added/removed: None

## Installation Steps (if applicable)

N/A

## Usage Examples (if applicable)

N/A

## Testing Done

Previewed the updated README to ensure the description renders correctly and that no unintended formatting changes occurred.

## Affected Files

- README.md

## Screenshots/Demo

N/A

## Checklist

- [x] Documentation updated
- [x] No breaking changes introduced

## Additional Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README section title to “Examples using Model Context Protocol,” replacing “Examples using Managed Compute Providers” to align with current terminology and improve clarity for readers.
  * Content and links within the section remain unchanged; this is a text-only update with no impact on functionality.
  * No user action required after update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->