### PR TITLE
Adding Sayna.ai, a self-hosted voice layer for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Interested in sponsoring this project? Feel free to reach out!
 - [DSPy Starter](starter_ai_agents/dspy_starter) - DSPy framework for building and optimizing AI systems.
 - [Google ADK Starter](starter_ai_agents/google_adk_starter) - Google Agent Development Kit starter.
 - [cagent Starter](starter_ai_agents/cagent_starter) - An open source and easy to use, customizable multi-agent runtime by Docker that orchestrates AI agents
+- [Sayna](https://github.com/SaynaAI/sayna) - Voice layer for AI agents with real-time STT/TTS, multi-provider support (Deepgram, ElevenLabs, Azure, Google), and WebSocket streaming.
 
 ### 🪶 Simple Agents
 


### PR DESCRIPTION
Adding [Sayna.ai](https://github.com/SaynaAI/sayna), which is a Rust-based self-hosted voice infrastructure for AI Agents. It handles everything that relates to the voice, like STT, TTS, SIP Telephony, Noise Suppression, TURN Taking, and nearly all providers for the voice. It is a great addition to the list, and a great way to get started with voice AI agents.

---
## EntelligenceAI PR Summary 
 This PR expands the AI agents starter resources documentation by adding a new voice layer solution.
- Added Sayna entry to README.md AI agents resources section
- Sayna provides real-time speech-to-text (STT) and text-to-speech (TTS) capabilities
- Supports multiple providers: Deepgram, ElevenLabs, Azure, and Google
- Features WebSocket streaming functionality for real-time voice processing
- Documentation-only change with no code modifications 

