### PR TITLE
Add mobile SSH agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Interested in sponsoring this project? Feel free to reach out!
 
 ### 🪶 Simple Agents
 
-**Straightforward, practical use-cases for everyday AI applications.** _14 projects_
+**Straightforward, practical use-cases for everyday AI applications.** _15 projects_
 
 - [Agno AI Examples](simple_ai_agents/agno_ai_examples) - Simple to multi-agent examples with web search & knowledge base
 - [Finance Agent](simple_ai_agents/finance_agent) - Real-time stock & market data tracking agent
@@ -231,6 +231,7 @@ Interested in sponsoring this project? Feel free to reach out!
 - [RouteLLM Chat](simple_ai_agents/llm_router) - Intelligent model routing with RouteLLM (GPT-4o-mini vs Nebius Llama) for cost optimization
 - [Talk to Your DB](simple_ai_agents/talk_to_db) - Natural language database queries with GibsonAI & LangChain
 - [Agent Discovery Agent](simple_ai_agents/agent_discovery_agent) - Find and compare AI agents across NANDA, MCP, Virtuals, A2A, and ERC-8004 registries
+- [Mobile SSH Agent](simple_ai_agents/mobile_ssh_agent) - Run AI coding agents (Claude Code, Codex, Aider) on a remote server via SSH from any device
 
 ### 🎙️ Voice Agents
 

--- a/simple_ai_agents/mobile_ssh_agent/.env.example
+++ b/simple_ai_agents/mobile_ssh_agent/.env.example
@@ -1,0 +1,9 @@
+# Remote server SSH credentials
+SSH_HOST="your-server.example.com"
+SSH_USER="your_username"
+SSH_PORT="22"
+SSH_KEY_PATH="~/.ssh/id_rsa"
+
+# Which coding agent to install and run
+# Options: claude, codex, aider
+AGENT_CLI="claude"

--- a/simple_ai_agents/mobile_ssh_agent/README.md
+++ b/simple_ai_agents/mobile_ssh_agent/README.md
@@ -1,0 +1,108 @@
+# Mobile SSH Agent
+
+> Run AI coding agents on a remote server and access them from anywhere — your laptop, phone, or tablet.
+
+A setup script that provisions a remote server with an AI coding agent (Claude Code, Codex CLI, or Aider) over SSH and starts an interactive session. Once configured, you can reconnect from any device with an SSH client.
+
+## How it Works
+
+The script connects to your remote server via SSH and:
+
+1. Checks connectivity and authentication
+2. Installs Node.js (via nvm) if the chosen agent requires it
+3. Installs the coding agent CLI globally
+4. Launches an interactive terminal session with the agent
+
+After the initial setup, you can connect directly from any SSH client — including mobile apps like [Onepilot](https://onepilotapp.com), Termius, or Blink Shell — and start the agent manually.
+
+## Why Remote Agents?
+
+Running coding agents on a remote server has a few practical benefits:
+
+- **Access from any device** — SSH in from your phone during a commute, or from a tablet on the couch
+- **Persistent sessions** — use `tmux` or `screen` so agent sessions survive disconnects
+- **Better hardware** — run agents on a machine with more RAM/CPU than your local device
+- **Consistent environment** — same dev setup regardless of which client you connect from
+
+## Prerequisites
+
+- Python 3.10+
+- A remote server (VPS, cloud instance, or home lab) with SSH access
+- An API key for your chosen agent:
+  - [Anthropic API key](https://console.anthropic.com/) for Claude Code
+  - [OpenAI API key](https://platform.openai.com/) for Codex CLI
+  - Any supported provider key for Aider
+
+## Setup
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/Arindam200/awesome-ai-apps.git
+   cd awesome-ai-apps/simple_ai_agents/mobile_ssh_agent
+   ```
+
+2. **Install dependencies:**
+
+   ```bash
+   pip install uv
+   uv sync
+   ```
+
+   Or with pip:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Configure environment variables:**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Edit `.env` with your server details:
+
+   ```env
+   SSH_HOST="your-server.example.com"
+   SSH_USER="your_username"
+   SSH_PORT="22"
+   SSH_KEY_PATH="~/.ssh/id_rsa"
+   AGENT_CLI="claude"
+   ```
+
+## Usage
+
+Run the setup script:
+
+```bash
+uv run main.py
+```
+
+This will connect to your server, install the agent if needed, and drop you into an interactive session.
+
+### Reconnecting Later
+
+Once set up, you can skip the script and SSH in directly:
+
+```bash
+ssh your-server.example.com
+claude  # or codex, aider
+```
+
+For persistent sessions that survive disconnects:
+
+```bash
+ssh your-server.example.com
+tmux new -s agent
+claude
+# Detach with Ctrl+B, D — reattach later with: tmux attach -t agent
+```
+
+## Supported Agents
+
+| Agent | Install Command | Requires |
+|-------|----------------|----------|
+| [Claude Code](https://github.com/anthropics/claude-code) | `npm install -g @anthropic-ai/claude-code` | Node.js, Anthropic API key |
+| [Codex CLI](https://github.com/openai/codex) | `npm install -g @openai/codex` | Node.js, OpenAI API key |
+| [Aider](https://github.com/paul-gauthier/aider) | `pip install aider-chat` | Python, any supported API key |

--- a/simple_ai_agents/mobile_ssh_agent/main.py
+++ b/simple_ai_agents/mobile_ssh_agent/main.py
@@ -1,0 +1,142 @@
+"""
+Mobile SSH Agent Setup
+
+Sets up a remote server for running AI coding agents (Claude Code, Codex CLI,
+Aider) over SSH — useful for accessing agents from mobile devices, tablets,
+or any thin client with an SSH app.
+
+Usage:
+    python main.py
+"""
+
+import os
+import subprocess
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SSH_HOST = os.getenv("SSH_HOST", "")
+SSH_USER = os.getenv("SSH_USER", "")
+SSH_PORT = os.getenv("SSH_PORT", "22")
+SSH_KEY_PATH = os.getenv("SSH_KEY_PATH", "~/.ssh/id_rsa")
+AGENT_CLI = os.getenv("AGENT_CLI", "claude")  # claude, codex, aider
+
+
+def run_ssh(command: str, interactive: bool = False):
+    """Run a command on the remote server via SSH."""
+    args = [
+        "ssh",
+        "-p", SSH_PORT,
+        "-i", os.path.expanduser(SSH_KEY_PATH),
+        "-o", "StrictHostKeyChecking=no",
+        f"{SSH_USER}@{SSH_HOST}",
+    ]
+    if interactive:
+        args.insert(1, "-t")
+    args.append(command)
+
+    if interactive:
+        return subprocess.run(args)
+    return subprocess.run(args, capture_output=True, text=True, timeout=60)
+
+
+def check_connection() -> bool:
+    """Verify SSH connectivity to the remote server."""
+    print(f"Connecting to {SSH_USER}@{SSH_HOST}:{SSH_PORT}...")
+    result = run_ssh("echo ok")
+    if result.returncode == 0:
+        print("SSH connection successful.")
+        return True
+    print("Failed to connect. Check your SSH credentials and server address.")
+    return False
+
+
+def ensure_node() -> bool:
+    """Check if Node.js is available; install via nvm if missing."""
+    result = run_ssh("node --version 2>/dev/null || echo MISSING")
+    if "MISSING" not in result.stdout:
+        print(f"Node.js found: {result.stdout.strip()}")
+        return True
+
+    print("Node.js not found. Installing via nvm...")
+    cmd = (
+        "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && "
+        'export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm install --lts'
+    )
+    result = run_ssh(cmd)
+    if result.returncode == 0:
+        print("Node.js installed.")
+        return True
+    print(f"Node.js install failed: {result.stderr}")
+    return False
+
+
+def install_agent(agent: str) -> bool:
+    """Install the specified coding agent CLI on the remote server."""
+    install_commands = {
+        "claude": "npm install -g @anthropic-ai/claude-code",
+        "codex": "npm install -g @openai/codex",
+        "aider": "pip install aider-chat",
+    }
+    cmd = install_commands.get(agent)
+    if not cmd:
+        print(f"Unknown agent: {agent}. Supported: {', '.join(install_commands)}")
+        return False
+
+    print(f"Installing {agent}...")
+    if agent in ("claude", "codex"):
+        cmd = f'export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" 2>/dev/null; {cmd}'
+
+    result = run_ssh(cmd)
+    if result.returncode == 0:
+        print(f"{agent} installed successfully.")
+        return True
+    print(f"Failed to install {agent}: {result.stderr}")
+    return False
+
+
+def start_session(agent: str):
+    """Open an interactive agent session on the remote server."""
+    print(f"\nStarting {agent} on {SSH_HOST}...")
+    print("Tip: you can also connect from your phone with a mobile SSH client.\n")
+
+    if agent in ("claude", "codex"):
+        cmd = f'export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" 2>/dev/null; {agent}'
+    else:
+        cmd = agent
+
+    run_ssh(cmd, interactive=True)
+
+
+def main():
+    if not SSH_HOST or not SSH_USER:
+        print("Error: SSH_HOST and SSH_USER must be set in your .env file.")
+        print("See .env.example for required variables.")
+        sys.exit(1)
+
+    if not check_connection():
+        sys.exit(1)
+
+    # Node.js is required for Claude Code and Codex CLI
+    if AGENT_CLI in ("claude", "codex") and not ensure_node():
+        print("Could not set up Node.js. Install it manually on the server.")
+        sys.exit(1)
+
+    # Check if agent is already installed
+    nvm_prefix = 'export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" 2>/dev/null; '
+    check_cmd = f"{nvm_prefix}which {AGENT_CLI} 2>/dev/null || echo MISSING"
+    result = run_ssh(check_cmd)
+
+    if "MISSING" in result.stdout:
+        if not install_agent(AGENT_CLI):
+            sys.exit(1)
+    else:
+        print(f"{AGENT_CLI} is already installed.")
+
+    start_session(AGENT_CLI)
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_ai_agents/mobile_ssh_agent/pyproject.toml
+++ b/simple_ai_agents/mobile_ssh_agent/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "mobile-ssh-agent"
+version = "0.1.0"
+description = "Set up and run AI coding agents on a remote server over SSH"
+requires-python = ">=3.10"
+dependencies = [
+    "python-dotenv>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.backends"


### PR DESCRIPTION
Adds mobile_ssh_agent under simple_ai_agents. A setup script to install and run AI coding agents on a remote server over SSH, so you can access them from any device.