### PR TITLE
Security: Wildcard CORS on MCP server endpoint

### DIFF
--- a/mcp_ai_agents/scalekit-exa-mcp-security/main.py
+++ b/mcp_ai_agents/scalekit-exa-mcp-security/main.py
@@ -16,13 +16,16 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# Add CORS middleware
+allowed_origins = getattr(settings, "ALLOWED_ORIGINS", [])
+if isinstance(allowed_origins, str):
+    allowed_origins = [origin.strip() for origin in allowed_origins.split(",") if origin.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify your actual origins
+    allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "Accept"],
 )
 
 


### PR DESCRIPTION
## Summary

Security: Wildcard CORS on MCP server endpoint

## Problem

**Severity**: `Medium` | **File**: `mcp_ai_agents/scalekit-exa-mcp-security/main.py:L21`

The server configures CORS with `allow_origins=["*"]` and broad methods/headers. Even with auth middleware, this expands cross-origin attack surface and can expose authenticated actions to untrusted browser contexts.

## Solution

Replace wildcard origin with an explicit allowlist, limit methods/headers to required values, and ensure auth tokens are not usable from arbitrary browser origins.

## Changes

- `mcp_ai_agents/scalekit-exa-mcp-security/main.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced