### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,3 +446,5 @@ For any questions, suggestions, or contributions, feel free to reach out to the 
 ## Thank You for the Support! 🙏
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Arindam200/awesome-ai-apps&type=Date)](https://www.star-history.com/#Arindam200/awesome-ai-apps&Date)
+
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** A collection of projects showcasing RAG, agents, workflows, and other AI use cases

Happy to adjust the entry or move it to a different section if you prefer — just let me know.