### PR TITLE
Fix README links in example projects

### DIFF
--- a/advance_ai_agents/candidate_analyser/README.md
+++ b/advance_ai_agents/candidate_analyser/README.md
@@ -146,7 +146,7 @@ Agent(
 ## 🔗 Links
 
 - [Agno Documentation](https://docs.agno.ai)
-- [Nebius](Nebius.com)
+- [Nebius](https://nebius.com)
 - [Exa Search](https://exa.ai)
 - [GitHubTools Docs](https://github.com/features/copilot)
 

--- a/advance_ai_agents/price_monitoring_agent/README.md
+++ b/advance_ai_agents/price_monitoring_agent/README.md
@@ -133,4 +133,4 @@ Contributions are welcome! Please submit a pull request or open an issue to disc
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/advance_ai_agents/startup_idea_validator_agent/README.md
+++ b/advance_ai_agents/startup_idea_validator_agent/README.md
@@ -105,4 +105,4 @@ Contributions are welcome! Please submit a pull request or open an issue to disc
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/course/aws_strands/06_multi_agent_pattern/06_4_workflow_agent/README.md
+++ b/course/aws_strands/06_multi_agent_pattern/06_4_workflow_agent/README.md
@@ -325,7 +325,7 @@ We welcome contributions to the Workflow Agent pattern! If you're interested in 
 
 1. **Join our Discord**: [discord.gg/strands](https://discord.gg/strands)
 2. **Check our GitHub**: [github.com/strands/strands](https://github.com/strands/strands)
-3. **Read our Contributing Guide**: [CONTRIBUTING.md](../../CONTRIBUTING.md)
+3. **Read our Contributing Guide**: [CONTRIBUTING.md](../../../../CONTRIBUTING.md)
 
 ---
 

--- a/mcp_ai_agents/doc_mcp/README.md
+++ b/mcp_ai_agents/doc_mcp/README.md
@@ -127,7 +127,7 @@ For detailed guides see:
 
 ## 📄 License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT License - see [LICENSE](../../LICENSE) file for details.
 
 ---
 

--- a/mcp_ai_agents/hotel_finder_agent/README.md
+++ b/mcp_ai_agents/hotel_finder_agent/README.md
@@ -219,7 +219,7 @@ We welcome contributions! Please follow these guidelines:
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 

--- a/rag_apps/agentic_rag_with_web_search/README.md
+++ b/rag_apps/agentic_rag_with_web_search/README.md
@@ -122,4 +122,4 @@ Contributions, issues, and feature requests are welcome! Feel free to check the 
 
 ## 📜 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/simple_ai_agents/nebius_chat/README.md
+++ b/simple_ai_agents/nebius_chat/README.md
@@ -205,7 +205,7 @@ CMD ["streamlit", "run", "app.py", "--server.port=8501"]
 
 ## 📝 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary
- fix README license links in nested example projects so they point to the root MIT license
- fix the AWS Strands workflow contribution guide link
- add the missing scheme to the Nebius link

## Verification
- checked local Markdown links in the changed files
- git diff --check