### PR TITLE
Add Nebius social campaign planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Interested in sponsoring this project? Feel free to reach out!
 
 ### 🪶 Simple Agents
 
-**Straightforward, practical use-cases for everyday AI applications.** _18 projects_
+**Straightforward, practical use-cases for everyday AI applications.** _19 projects_
 
 - [Agno Agent Examples](simple_ai_agents/agno_ai_examples): Simple to multi-agent examples with web search and a knowledge base
 - [Agno Agent UI](simple_ai_agents/agno_ui_agent): Interactive UI for web and finance agents
@@ -223,6 +223,7 @@ Interested in sponsoring this project? Feel free to reach out!
 - [Natural-Language Database Assistant](simple_ai_agents/talk_to_db): Natural language database queries with GibsonAI and LangChain
 - [Natural-Language SQL Agent (LangChain)](simple_ai_agents/langchain_data_agent_poc): Natural-language-to-SQL data agent with LangGraph, Nebius, read-only SQL safety, and Streamlit charts
 - [Nebius Chat](simple_ai_agents/nebius_chat): Chat interface for Nebius Token Factory
+- [Nebius Social Campaign Planner](simple_ai_agents/nebius_social_campaign_planner): Streamlit app that turns a launch brief into social posts, content pillars, and a 7-day calendar with Nebius
 - [Newsletter Generator](simple_ai_agents/newsletter_agent): AI-powered newsletter builder with Firecrawl integration
 - [Stock Market Finance Agent](simple_ai_agents/finance_agent): Real-time stock and market data tracking agent
 - [Stock Portfolio Analyst](simple_ai_agents/stock_portfolio_analyst): Live portfolio valuation, concentration analysis, risk flags, and rebalancing ideas with Agno

--- a/simple_ai_agents/nebius_social_campaign_planner/.env.example
+++ b/simple_ai_agents/nebius_social_campaign_planner/.env.example
@@ -1,0 +1,1 @@
+NEBIUS_API_KEY=your_nebius_api_key_here

--- a/simple_ai_agents/nebius_social_campaign_planner/README.md
+++ b/simple_ai_agents/nebius_social_campaign_planner/README.md
@@ -1,0 +1,107 @@
+# Nebius Social Campaign Planner
+
+> A Streamlit app that turns a product brief into a launch-ready social media campaign with Nebius.
+
+This project uses Nebius through `langchain-nebius` to generate content pillars, channel-specific posts, a 7-day calendar, and a pre-publish review checklist from a short product brief.
+
+## Features
+
+- **Campaign Strategy**: Generate positioning and content pillars from a product brief.
+- **Channel-Specific Posts**: Draft posts for X/Twitter, LinkedIn, Reddit, newsletters, and Product Hunt.
+- **Launch Calendar**: Build a 7-day campaign plan with daily tasks.
+- **Review Checklist**: Add quality and safety checks before publishing.
+- **Streamlit UI**: Run the workflow locally without extra frontend setup.
+
+## Tech Stack
+
+- **Python**: Core application language
+- **Streamlit**: Interactive web UI
+- **Nebius**: LLM provider for campaign generation
+- **LangChain Nebius**: Nebius chat model integration
+- **python-dotenv**: Local environment loading
+
+## Workflow
+
+```mermaid
+flowchart LR
+    A[Product Brief] --> B[Audience and Goal]
+    B --> C[Nebius Campaign Planner]
+    C --> D[Content Pillars]
+    C --> E[Social Posts]
+    C --> F[7-Day Calendar]
+    C --> G[Review Checklist]
+```
+
+1. Enter a product or launch brief.
+2. Choose audience, campaign goal, tone, and channels.
+3. Nebius generates a structured JSON campaign plan.
+4. Review and copy the posts or calendar into your publishing workflow.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv) or pip
+- Nebius API key
+
+### Environment Variables
+
+Create a `.env` file in this project directory:
+
+```env
+NEBIUS_API_KEY=your_nebius_api_key_here
+```
+
+### Installation
+
+Clone the repository and open the project directory:
+
+```bash
+git clone https://github.com/Arindam200/awesome-ai-apps.git
+cd awesome-ai-apps/simple_ai_agents/nebius_social_campaign_planner
+```
+
+Install dependencies:
+
+```bash
+uv sync
+```
+
+Or with pip:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install streamlit langchain-nebius langchain-core python-dotenv
+```
+
+## Usage
+
+Run the app:
+
+```bash
+uv run streamlit run app.py
+```
+
+Open the local Streamlit URL, add your Nebius API key, fill in the campaign brief, and click **Generate Campaign**.
+
+## Project Structure
+
+```text
+nebius_social_campaign_planner/
+├── .env.example
+├── app.py
+├── pyproject.toml
+└── README.md
+```
+
+## Notes
+
+- The app asks Nebius for valid JSON and renders each campaign section separately.
+- Generated copy should be reviewed before publishing.
+- No social platform credentials are required because this project focuses on planning and drafting.
+
+## License
+
+This project is licensed under the MIT License. See the repository [LICENSE](../../LICENSE) file for details.

--- a/simple_ai_agents/nebius_social_campaign_planner/app.py
+++ b/simple_ai_agents/nebius_social_campaign_planner/app.py
@@ -1,0 +1,193 @@
+"""Nebius-powered social campaign planner."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import streamlit as st
+from dotenv import load_dotenv
+from langchain_nebius import ChatNebius
+
+load_dotenv()
+
+DEFAULT_MODEL = "zai-org/GLM-4.5-Air"
+
+
+def build_campaign_prompt(
+    product: str,
+    audience: str,
+    goal: str,
+    channels: list[str],
+    tone: str,
+) -> str:
+    """Build a structured prompt for a launch-ready social campaign."""
+    channel_list = ", ".join(channels)
+    return f"""
+You are a senior social strategist. Build a practical social campaign for this
+product using the requested channels.
+
+Product:
+{product}
+
+Audience:
+{audience}
+
+Goal:
+{goal}
+
+Channels:
+{channel_list}
+
+Tone:
+{tone}
+
+Return valid JSON with these keys:
+- positioning: one concise paragraph
+- content_pillars: array of 4 pillar objects with name and angle
+- posts: array of 6 objects with channel, hook, body, cta, and rationale
+- seven_day_calendar: array of 7 objects with day, channel, post_theme, and task
+- review_checklist: array of short safety and quality checks before publishing
+
+Keep post bodies publishable, specific, and free of placeholders.
+""".strip()
+
+
+def parse_json_response(content: str) -> dict[str, Any]:
+    """Parse JSON even when the model wraps it in Markdown fences."""
+    text = content.strip()
+    if text.startswith("```json"):
+        text = text.removeprefix("```json").strip()
+    if text.startswith("```"):
+        text = text.removeprefix("```").strip()
+    if text.endswith("```"):
+        text = text.removesuffix("```").strip()
+    return json.loads(text)
+
+
+def generate_campaign(
+    api_key: str,
+    model: str,
+    temperature: float,
+    product: str,
+    audience: str,
+    goal: str,
+    channels: list[str],
+    tone: str,
+) -> dict[str, Any]:
+    """Call Nebius and return the parsed campaign plan."""
+    llm = ChatNebius(api_key=api_key, model=model, temperature=temperature)
+    prompt = build_campaign_prompt(product, audience, goal, channels, tone)
+    response = llm.invoke(prompt)
+    content = str(response.content)
+    return parse_json_response(content)
+
+
+def render_posts(posts: list[dict[str, Any]]) -> None:
+    """Render generated social posts."""
+    for post in posts:
+        with st.container(border=True):
+            st.caption(str(post.get("channel", "Channel")))
+            st.subheader(str(post.get("hook", "Post")))
+            st.write(str(post.get("body", "")))
+            st.markdown(f"**CTA:** {post.get('cta', '')}")
+            st.caption(str(post.get("rationale", "")))
+
+
+def main() -> None:
+    """Run the Streamlit app."""
+    st.set_page_config(page_title="Nebius Social Campaign Planner", page_icon="📣")
+    st.title("Nebius Social Campaign Planner")
+    st.write(
+        "Turn a product brief into channel-specific posts, content pillars, "
+        "and a 7-day launch calendar powered by Nebius."
+    )
+
+    with st.sidebar:
+        st.header("Nebius")
+        api_key = st.text_input(
+            "NEBIUS_API_KEY",
+            value=os.getenv("NEBIUS_API_KEY", ""),
+            type="password",
+        )
+        model = st.text_input("Model", value=DEFAULT_MODEL)
+        temperature = st.slider("Temperature", 0.0, 1.0, 0.55, 0.05)
+
+    with st.form("campaign_form"):
+        product = st.text_area(
+            "Product or launch brief",
+            value=(
+                "A developer tool that helps teams review pull requests faster "
+                "with AI-generated risk summaries."
+            ),
+            height=120,
+        )
+        audience = st.text_input(
+            "Target audience",
+            value="Engineering managers and senior developers at SaaS teams",
+        )
+        goal = st.text_input(
+            "Campaign goal",
+            value="Drive waitlist signups for a private beta",
+        )
+        channels = st.multiselect(
+            "Channels",
+            ["X/Twitter", "LinkedIn", "Reddit", "Newsletter", "Product Hunt"],
+            default=["X/Twitter", "LinkedIn", "Newsletter"],
+        )
+        tone = st.selectbox(
+            "Tone",
+            ["Clear and practical", "Founder-led", "Technical", "Playful"],
+        )
+        submitted = st.form_submit_button("Generate Campaign")
+
+    if submitted:
+        if not api_key:
+            st.error("Add NEBIUS_API_KEY to generate a campaign.")
+            return
+        if not channels:
+            st.error("Select at least 1 channel.")
+            return
+
+        with st.spinner("Generating campaign with Nebius..."):
+            try:
+                campaign = generate_campaign(
+                    api_key=api_key,
+                    model=model,
+                    temperature=temperature,
+                    product=product,
+                    audience=audience,
+                    goal=goal,
+                    channels=channels,
+                    tone=tone,
+                )
+            except (json.JSONDecodeError, ValueError) as error:
+                st.error(f"Nebius returned invalid JSON: {error}")
+                return
+            except Exception as error:  # noqa: BLE001
+                st.error(f"Campaign generation failed: {error}")
+                return
+
+        st.header("Positioning")
+        st.write(str(campaign.get("positioning", "")))
+
+        st.header("Content Pillars")
+        for pillar in campaign.get("content_pillars", []):
+            st.markdown(
+                f"- **{pillar.get('name', 'Pillar')}**: {pillar.get('angle', '')}"
+            )
+
+        st.header("Generated Posts")
+        render_posts(campaign.get("posts", []))
+
+        st.header("7-Day Calendar")
+        st.dataframe(campaign.get("seven_day_calendar", []), use_container_width=True)
+
+        st.header("Review Checklist")
+        for item in campaign.get("review_checklist", []):
+            st.checkbox(str(item), value=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_ai_agents/nebius_social_campaign_planner/pyproject.toml
+++ b/simple_ai_agents/nebius_social_campaign_planner/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "nebius-social-campaign-planner"
+version = "0.1.0"
+description = "Streamlit app that uses Nebius to plan launch-ready social campaigns."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "langchain-core>=0.3.0",
+    "langchain-nebius>=0.1.3",
+    "python-dotenv>=1.1.1",
+    "streamlit>=1.48.1",
+]


### PR DESCRIPTION
## Summary

- add a working Nebius-powered Streamlit social campaign planner
- generate positioning, content pillars, channel drafts, a 7-day calendar, and a review checklist
- include isolated setup, environment, usage, and project documentation
- register the new project in the current root catalogue
- synchronize the branch with current `main` and resolve the catalogue conflict

## Validation

- isolated `uv` install against the current `langchain-nebius` package
- adapter smoke covering `ChatNebius` construction, prompt handoff through `invoke`, and structured response parsing
- `python3 -m py_compile simple_ai_agents/nebius_social_campaign_planner/app.py`
- scoped `git diff --check`

A live provider call or video still requires a Nebius API credential. The exact public head is ready for maintainer-side credential verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Streamlit-based social media campaign planner that turns a product brief into a full launch-ready plan: positioning, content pillars, channel-specific post drafts, a 7-day calendar, and a pre-publish review checklist.
  * Users can customize audience, goal, channels, tone, and generation settings via an interactive interface.

* **Documentation**
  * Added a dedicated agent README covering prerequisites, setup, how to run, and required configuration.
  * Updated the main “Simple Agents” list to include the new planner.

* **Chores**
  * Added example environment configuration and an initial project manifest for the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->