### PR TITLE
Add Auferet (memory-first AI game master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Interested in sponsoring this project? Feel free to reach out!
 ### 🎓 Course Playlists
 
 - [**AWS Strands Course**](https://www.youtube.com/playlist?list=PLMZM1DAlf0Lrc43ZtUXAwYu9DhnqxzRKZ) - Complete 8-lesson course on building AI agents with AWS Strands SDK
+[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 
 ### 🔧 Framework Tutorials
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Interested in sponsoring this project? Feel free to reach out!
 ### 🎓 Course Playlists
 
 - [**AWS Strands Course**](https://www.youtube.com/playlist?list=PLMZM1DAlf0Lrc43ZtUXAwYu9DhnqxzRKZ) - Complete 8-lesson course on building AI agents with AWS Strands SDK
-[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
+- [Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 
 ### 🔧 Framework Tutorials
 


### PR DESCRIPTION
Adds Auferet, an AI game master for solo and multiplayer roleplaying games. It keeps your characters, world, and events in persistent memory and reads lore you upload, so the story stays consistent across long campaigns. Runs 5e and Pathfinder 2e, plays in the browser and on Android, free to start.

Website: https://auferet.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Tutorials & Videos section by adding a new **Auferet** course playlist entry, including a link to the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->