### PR TITLE
Add llm-box: terminal-first AI workflow engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ Interested in sponsoring this project? Feel free to reach out!
 
 ### 🧩 Starter Agents
 
-- **[llm-box](https://github.com/alib8b8/llm-box)** - Terminal-first AI workflow engine. Orchestrate multi-model LLM pipelines with YAML, Bubble Tea TUI, and 15+ model providers.
-**Quick-start agents for learning and extending different AI frameworks.** _20 projects_
+**Quick-start agents for learning and extending different AI frameworks.** _21 projects_
 
 - [Agno HackerNews Analysis](starter_ai_agents/agno_starter) - Agno-based agent for trend analysis on HackerNews
 - [OpenAI SDK Starter](starter_ai_agents/openai_agents_sdk) - OpenAI Agents SDK with email helper & haiku writer examples
@@ -220,6 +219,7 @@ Interested in sponsoring this project? Feel free to reach out!
 - [cagent Starter](starter_ai_agents/cagent_starter) - Open-source customizable multi-agent runtime by Docker
 - [Sayna Voice Agent](starter_ai_agents/sayna_starter) - Real-time voice infrastructure with multi-provider STT/TTS (Deepgram, ElevenLabs, Azure, Google) and WebSocket streaming
 - [KAOS Starter](starter_ai_agents/kaos_starter) - Kubernetes-native multi-agent system with MCP tools and in-cluster LLM
+- **[llm-box](https://github.com/alib8b8/llm-box)** - Terminal-first AI workflow engine. Orchestrate multi-model LLM pipelines with YAML, Bubble Tea TUI, and 15+ model providers.
 
 ### 🪶 Simple Agents
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Interested in sponsoring this project? Feel free to reach out!
 
 ### 🧩 Starter Agents
 
+- **[llm-box](https://github.com/alib8b8/llm-box)** - Terminal-first AI workflow engine. Orchestrate multi-model LLM pipelines with YAML, Bubble Tea TUI, and 15+ model providers.
 **Quick-start agents for learning and extending different AI frameworks.** _20 projects_
 
 - [Agno HackerNews Analysis](starter_ai_agents/agno_starter) - Agno-based agent for trend analysis on HackerNews


### PR DESCRIPTION
Hi! I'd like to suggest adding [llm-box](https://github.com/alib8b8/llm-box) - a terminal-first AI workflow engine with:

- Beautiful TUI built with Bubble Tea
- YAML-defined LLM pipelines
- 15+ model providers (DeepSeek, GLM, Kimi, Qwen, InternLM, Ollama, etc.)
- Multi-language plugin support
- Built-in expression engine, condition nodes, and execution history

Thanks for maintaining this awesome list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Quick-start agents” count to 21.
  * Added a new “llm-box” entry to the Starter Agents list under Featured AI Apps, including its link and a brief description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->