### PR TITLE
Add MiniMax provider configuration

### DIFF
--- a/advance_ai_agents/financial_document_os/.env.example
+++ b/advance_ai_agents/financial_document_os/.env.example
@@ -2,13 +2,20 @@
 UNSILOED_API_KEY=
 
 # --- LLM provider (NL→SQL, synthesis, sentiment, anomaly hints) ---
-# Default is OpenAI. Set LLM_PROVIDER to switch: openai | anthropic | nebius
+# Default is OpenAI. Set LLM_PROVIDER to switch: openai | anthropic | nebius | minimax
 LLM_PROVIDER=openai
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 # Nebius Token Factory (OpenAI-compatible). Only used when LLM_PROVIDER=nebius.
 NEBIUS_API_KEY=
 # NEBIUS_SYNTHESIS_MODEL=nvidia/Nemotron-3-Ultra-550b-a55b
+# MiniMax. Only used when LLM_PROVIDER=minimax.
+MINIMAX_API_KEY=
+# Choose global_en or cn_zh, then choose openai or anthropic-compatible requests.
+# MINIMAX_REGION=global_en
+# MINIMAX_PROTOCOL=openai
+# MINIMAX_SYNTHESIS_MODEL=MiniMax-M3
+# MINIMAX_SENTIMENT_MODEL=MiniMax-M2.7
 
 # Resend — board report email (stretch)
 RESEND_API_KEY=

--- a/advance_ai_agents/financial_document_os/README.md
+++ b/advance_ai_agents/financial_document_os/README.md
@@ -26,7 +26,7 @@ every answer carries a clickable citation back to the source pixel.
 - [Prerequisites](#prerequisites)
 - [Setup & run](#setup--run)
 - [Environment variables](#environment-variables)
-- [Choosing an LLM provider (OpenAI / Nebius / Anthropic)](#choosing-an-llm-provider)
+- [Choosing an LLM provider](#choosing-an-llm-provider)
 - [Using the app](#using-the-app)
 - [The Edit API (calibrated first)](#the-edit-api-calibrated-first)
 - [API reference](#api-reference)
@@ -102,8 +102,8 @@ anomaly rules.
 - **Backend** — Python · FastAPI · SQLAlchemy · PostgreSQL
 - **Frontend** — Next.js 15 · React 19 · Tailwind v4
 - **Documents** — Unsiloed APIs (classify / extract / parse / edit) · pymupdf for page rendering
-- **LLM** (NL→SQL + synthesis) — OpenAI by default; pluggable to **Nebius Token Factory**
-  or Anthropic (see [below](#choosing-an-llm-provider))
+- **LLM** (NL→SQL + synthesis) — OpenAI by default; pluggable to **Nebius Token Factory**,
+  Anthropic, or MiniMax (see [below](#choosing-an-llm-provider))
 - **NL→SQL safety** — read-only Postgres role + `sqlglot` SELECT-only AST allowlist
 
 ## The demo corpus (included PDFs)
@@ -138,7 +138,7 @@ pages — this is what genuinely exercises Unsiloed's table extraction), **contr
 - **Python 3.11+** and [`uv`](https://github.com/astral-sh/uv) (or pip)
 - **Node 18+** and [`pnpm`](https://pnpm.io)
 - An **Unsiloed API key** → https://unsiloed.ai
-- An **LLM key** — OpenAI by default, or a Nebius / Anthropic key (see below)
+- An **LLM key** — OpenAI by default, or a Nebius, Anthropic, or MiniMax key (see below)
 
 ## Setup & run
 
@@ -181,10 +181,15 @@ Documents page, click **Process**, and explore.
 | Variable | Required | Description |
 |---|---|---|
 | `UNSILOED_API_KEY` | ✅ | Unsiloed key for classify / extract / parse / edit. |
-| `LLM_PROVIDER` | – | `openai` (default), `nebius`, or `anthropic`. |
+| `LLM_PROVIDER` | – | `openai` (default), `nebius`, `anthropic`, or `minimax`. |
 | `OPENAI_API_KEY` | ✅ (default provider) | Used for NL→SQL + synthesis when provider is `openai`. |
 | `NEBIUS_API_KEY` | when `LLM_PROVIDER=nebius` | Nebius Token Factory key. |
 | `ANTHROPIC_API_KEY` | when `LLM_PROVIDER=anthropic` | Anthropic key. |
+| `MINIMAX_API_KEY` | when `LLM_PROVIDER=minimax` | MiniMax API key. |
+| `MINIMAX_REGION` | when `LLM_PROVIDER=minimax` | `global_en` or `cn_zh`; selects the matching regional endpoints. |
+| `MINIMAX_PROTOCOL` | when `LLM_PROVIDER=minimax` | `openai` or `anthropic`; selects the compatible API. |
+| `MINIMAX_SYNTHESIS_MODEL` | – | Defaults to `MiniMax-M3`. |
+| `MINIMAX_SENTIMENT_MODEL` | – | Defaults to `MiniMax-M2.7`. |
 | `RESEND_API_KEY` | optional | Board-report email (stretch feature). |
 | `DATABASE_URL` | ✅ | Primary Postgres connection (compose default provided). |
 | `DATABASE_READONLY_URL` | ✅ | Read-only role connection for NL→SQL. |
@@ -204,6 +209,13 @@ key, then restart the backend.
   OpenAI SDK against Nebius's `base_url` and falls back to JSON-object mode + Pydantic
   validation if a model doesn't support structured parse.
 - **Anthropic** — `LLM_PROVIDER=anthropic`, `ANTHROPIC_API_KEY=...`
+- **MiniMax** — `LLM_PROVIDER=minimax`, `MINIMAX_API_KEY=...`. Set
+  `MINIMAX_REGION=global_en` or `cn_zh` and choose `MINIMAX_PROTOCOL=openai` or
+  `anthropic`. The default models are `MiniMax-M3` for synthesis and `MiniMax-M2.7`
+  for sentiment. OpenAI-compatible requests use the regional `/v1` endpoint; Anthropic-
+  compatible requests use the regional `/anthropic` endpoint. See the [global API
+  overview](https://platform.minimax.io/docs/api-reference/api-overview) or [China API
+  overview](https://platform.minimaxi.com/docs/api-reference/api-overview).
 
 ## Using the app
 

--- a/advance_ai_agents/financial_document_os/backend/app/config.py
+++ b/advance_ai_agents/financial_document_os/backend/app/config.py
@@ -2,6 +2,17 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+MINIMAX_ENDPOINTS = {
+    "global_en": {
+        "openai": "https://api.minimax.io/v1",
+        "anthropic": "https://api.minimax.io/anthropic",
+    },
+    "cn_zh": {
+        "openai": "https://api.minimaxi.com/v1",
+        "anthropic": "https://api.minimaxi.com/anthropic",
+    },
+}
+
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 REPO_DIR = BACKEND_DIR.parent
 DATA_DIR = BACKEND_DIR / "data"
@@ -31,7 +42,7 @@ class Settings(BaseSettings):
     unsiloed_edit_base_url: str = "https://platformbackend.unsiloed.ai"
     unsiloed_model: str = "beta"
 
-    # LLM provider: auto (anthropic if key else openai) | openai | anthropic | nebius
+    # LLM provider: auto (anthropic if key else openai) | openai | anthropic | nebius | minimax
     llm_provider: str = "auto"
     synthesis_model: str = "claude-opus-4-8"
     sentiment_model: str = "claude-haiku-4-5-20251001"
@@ -41,6 +52,12 @@ class Settings(BaseSettings):
     nebius_base_url: str = "https://api.tokenfactory.us-central1.nebius.com/v1/"
     nebius_synthesis_model: str = "nvidia/Nemotron-3-Ultra-550b-a55b"
     nebius_sentiment_model: str = "nvidia/Nemotron-3-Ultra-550b-a55b"
+    # MiniMax supports OpenAI-compatible and Anthropic-compatible requests.
+    minimax_api_key: str = ""
+    minimax_region: str = "global_en"
+    minimax_protocol: str = "openai"
+    minimax_synthesis_model: str = "MiniMax-M3"
+    minimax_sentiment_model: str = "MiniMax-M2.7"
 
     # Feature flag — calibration passed 2026-06-13 (scripts/calibrate_edit.py),
     # edit bbox space = citation corners as-is
@@ -48,6 +65,19 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+def minimax_base_url(protocol: str) -> str:
+    region = (settings.minimax_region or "global_en").lower()
+    protocol = protocol.lower()
+    try:
+        return MINIMAX_ENDPOINTS[region][protocol]
+    except KeyError as exc:
+        raise ValueError(
+            "MINIMAX_REGION must be global_en or cn_zh and "
+            "MINIMAX_PROTOCOL must be openai or anthropic"
+        ) from exc
+
 
 for _d in (DOCS_DIR, PAGES_DIR, EDITED_DIR):
     _d.mkdir(parents=True, exist_ok=True)

--- a/advance_ai_agents/financial_document_os/backend/app/intelligence/llm.py
+++ b/advance_ai_agents/financial_document_os/backend/app/intelligence/llm.py
@@ -2,9 +2,9 @@
 
 Provider is chosen by settings.llm_provider:
   - "auto" (default): Anthropic if its key is set, else OpenAI.
-  - "openai" | "anthropic" | "nebius": forced.
-Nebius Token Factory is OpenAI-compatible (custom base_url) — set LLM_PROVIDER=nebius
-+ NEBIUS_API_KEY to use it. All paths return a validated Pydantic instance.
+  - "openai" | "anthropic" | "nebius" | "minimax": forced.
+OpenAI-compatible providers use a custom base_url when configured. All paths return
+a validated Pydantic instance.
 """
 
 import json
@@ -13,7 +13,7 @@ from typing import TypeVar
 
 from pydantic import BaseModel
 
-from app.config import settings
+from app.config import minimax_base_url, settings
 
 logger = logging.getLogger(__name__)
 
@@ -25,18 +25,20 @@ TIER_MODELS = {
         "anthropic": settings.synthesis_model,
         "openai": settings.openai_synthesis_model,
         "nebius": settings.nebius_synthesis_model,
+        "minimax": settings.minimax_synthesis_model,
     },
     "sentiment": {
         "anthropic": settings.sentiment_model,
         "openai": settings.openai_sentiment_model,
         "nebius": settings.nebius_sentiment_model,
+        "minimax": settings.minimax_sentiment_model,
     },
 }
 
 
 def _resolve_provider() -> str:
     p = (settings.llm_provider or "auto").lower()
-    if p in ("openai", "anthropic", "nebius"):
+    if p in ("openai", "anthropic", "nebius", "minimax"):
         return p
     return "anthropic" if settings.anthropic_api_key else "openai"
 
@@ -45,7 +47,7 @@ def _openai_compatible_parse(
     *, api_key: str, base_url: str | None, model: str,
     system: str, user_content: str, output_model: type[T], max_tokens: int,
 ) -> T | None:
-    """Shared path for OpenAI and any OpenAI-compatible endpoint (Nebius).
+    """Shared path for OpenAI and any OpenAI-compatible endpoint.
     Tries native structured outputs; falls back to JSON-object mode + manual
     validation for endpoints/models that don't support json_schema."""
     from openai import OpenAI
@@ -107,6 +109,39 @@ def parse_structured(
             **kwargs,
         )
         return response.parsed_output
+
+    if provider == "minimax":
+        if not settings.minimax_api_key:
+            raise RuntimeError("LLM_PROVIDER=minimax but MINIMAX_API_KEY is not set")
+        protocol = (settings.minimax_protocol or "openai").lower()
+        if protocol == "anthropic":
+            import anthropic
+
+            client = anthropic.Anthropic(
+                api_key=settings.minimax_api_key,
+                base_url=minimax_base_url("anthropic"),
+            )
+            kwargs = {"thinking": {"type": "adaptive"}} if tier == "synthesis" else {}
+            response = client.messages.parse(
+                model=models["minimax"],
+                max_tokens=max_tokens,
+                system=system,
+                messages=[{"role": "user", "content": user_content}],
+                output_format=output_model,
+                **kwargs,
+            )
+            return response.parsed_output
+        if protocol == "openai":
+            return _openai_compatible_parse(
+                api_key=settings.minimax_api_key,
+                base_url=minimax_base_url("openai"),
+                model=models["minimax"],
+                system=system,
+                user_content=user_content,
+                output_model=output_model,
+                max_tokens=max_tokens,
+            )
+        raise ValueError("MINIMAX_PROTOCOL must be openai or anthropic")
 
     if provider == "nebius":
         if not settings.nebius_api_key:

--- a/advance_ai_agents/maintainer_brief/.env.example
+++ b/advance_ai_agents/maintainer_brief/.env.example
@@ -5,13 +5,20 @@
 # enough. Using a token also raises the API rate limit to 5,000 req/hr.
 GITHUB_TOKEN=
 
-# LLM provider for brief synthesis. Default OpenAI; switch to nebius/anthropic.
+# LLM provider for brief synthesis. Default OpenAI; switch to nebius/anthropic/minimax.
 LLM_PROVIDER=openai
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 # Nebius Token Factory (OpenAI-compatible). Only used when LLM_PROVIDER=nebius.
 NEBIUS_API_KEY=
 # NEBIUS_SYNTHESIS_MODEL=nvidia/Nemotron-3-Ultra-550b-a55b
+# MiniMax. Only used when LLM_PROVIDER=minimax.
+MINIMAX_API_KEY=
+# Choose global_en or cn_zh, then choose openai or anthropic-compatible requests.
+# MINIMAX_REGION=global_en
+# MINIMAX_PROTOCOL=openai
+# MINIMAX_SYNTHESIS_MODEL=MiniMax-M3
+# MINIMAX_SENTIMENT_MODEL=MiniMax-M2.7
 
 # Postgres. Local dev default below; in prod use your Neon pooled URL, e.g.
 # postgresql+psycopg://USER:PASS@ep-xxx-pooler.REGION.aws.neon.tech/db?sslmode=require

--- a/advance_ai_agents/maintainer_brief/README.md
+++ b/advance_ai_agents/maintainer_brief/README.md
@@ -42,7 +42,7 @@ per source.
 
 - **Backend** — Python / FastAPI, SQLAlchemy, PostgreSQL, APScheduler (cron), pymupdf (page rendering)
 - **Extraction** — Unsiloed `/classify` + `/v2/extract` (async jobs, schema registry in `backend/app/unsiloed/schemas/`)
-- **Intelligence** — Claude (structured outputs via `messages.parse`) for the brief; Haiku for batched sentiment
+- **Intelligence** — configurable structured LLM outputs for the brief and batched sentiment
 - **Email** — Jinja2 table-layout HTML via Resend
 - **Frontend** — Next.js + Tailwind: brief viewer, signals explorer, citation viewer
 
@@ -50,7 +50,7 @@ per source.
 
 ```bash
 # 1. Keys
-cp .env.example .env   # fill in UNSILOED_API_KEY, ANTHROPIC_API_KEY, RESEND_API_KEY, GITHUB_TOKEN
+cp .env.example .env   # fill in UNSILOED_API_KEY, an LLM key, RESEND_API_KEY, GITHUB_TOKEN
 
 # 2. Postgres
 docker compose up -d
@@ -72,6 +72,16 @@ Then either click **Run brief now** on the dashboard, or:
 curl -X POST localhost:8000/runs -H "Content-Type: application/json" \
   -d '{"project_id": 1, "dry_run": true}'   # dry_run skips the email send
 ```
+
+## LLM provider configuration
+
+Set `LLM_PROVIDER=minimax` and provide `MINIMAX_API_KEY` to use MiniMax. Set
+`MINIMAX_REGION=global_en` or `cn_zh` to select the regional endpoints, then set
+`MINIMAX_PROTOCOL=openai` or `anthropic` to select the compatible API. The default
+models are `MiniMax-M3` for synthesis and `MiniMax-M2.7` for sentiment. OpenAI-compatible
+requests use the regional `/v1` endpoint, while Anthropic-compatible requests use the
+regional `/anthropic` endpoint. See the [global API overview](https://platform.minimax.io/docs/api-reference/api-overview)
+or [China API overview](https://platform.minimaxi.com/docs/api-reference/api-overview).
 
 ## Configure your project
 

--- a/advance_ai_agents/maintainer_brief/backend/app/config.py
+++ b/advance_ai_agents/maintainer_brief/backend/app/config.py
@@ -2,6 +2,17 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+MINIMAX_ENDPOINTS = {
+    "global_en": {
+        "openai": "https://api.minimax.io/v1",
+        "anthropic": "https://api.minimax.io/anthropic",
+    },
+    "cn_zh": {
+        "openai": "https://api.minimaxi.com/v1",
+        "anthropic": "https://api.minimaxi.com/anthropic",
+    },
+}
+
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 REPO_DIR = BACKEND_DIR.parent
 DATA_DIR = BACKEND_DIR / "data"
@@ -43,7 +54,7 @@ class Settings(BaseSettings):
     unsiloed_base_url: str = "https://prod.visionapi.unsiloed.ai"
     unsiloed_model: str = "beta"
 
-    # LLM provider: auto (anthropic if key else openai) | openai | anthropic | nebius
+    # LLM provider: auto (anthropic if key else openai) | openai | anthropic | nebius | minimax
     llm_provider: str = "auto"
     synthesis_model: str = "claude-opus-4-8"
     sentiment_model: str = "claude-haiku-4-5-20251001"
@@ -53,11 +64,30 @@ class Settings(BaseSettings):
     nebius_base_url: str = "https://api.tokenfactory.us-central1.nebius.com/v1/"
     nebius_synthesis_model: str = "nvidia/Nemotron-3-Ultra-550b-a55b"
     nebius_sentiment_model: str = "nvidia/Nemotron-3-Ultra-550b-a55b"
+    # MiniMax supports OpenAI-compatible and Anthropic-compatible requests.
+    minimax_api_key: str = ""
+    minimax_region: str = "global_en"
+    minimax_protocol: str = "openai"
+    minimax_synthesis_model: str = "MiniMax-M3"
+    minimax_sentiment_model: str = "MiniMax-M2.7"
 
     newsletter_from: str = "Maintainer Brief <onboarding@resend.dev>"
 
 
 settings = Settings()
+
+
+def minimax_base_url(protocol: str) -> str:
+    region = (settings.minimax_region or "global_en").lower()
+    protocol = protocol.lower()
+    try:
+        return MINIMAX_ENDPOINTS[region][protocol]
+    except KeyError as exc:
+        raise ValueError(
+            "MINIMAX_REGION must be global_en or cn_zh and "
+            "MINIMAX_PROTOCOL must be openai or anthropic"
+        ) from exc
+
 
 for _d in (DOCS_DIR, PAGES_DIR):
     _d.mkdir(parents=True, exist_ok=True)

--- a/advance_ai_agents/maintainer_brief/backend/app/intelligence/llm.py
+++ b/advance_ai_agents/maintainer_brief/backend/app/intelligence/llm.py
@@ -2,9 +2,9 @@
 
 Provider is chosen by settings.llm_provider:
   - "auto" (default): Anthropic if its key is set, else OpenAI.
-  - "openai" | "anthropic" | "nebius": forced.
-Nebius Token Factory is OpenAI-compatible (custom base_url) — set LLM_PROVIDER=nebius
-+ NEBIUS_API_KEY to use it. All paths return a validated Pydantic instance.
+  - "openai" | "anthropic" | "nebius" | "minimax": forced.
+OpenAI-compatible providers use a custom base_url when configured. All paths return
+a validated Pydantic instance.
 """
 
 import json
@@ -13,7 +13,7 @@ from typing import TypeVar
 
 from pydantic import BaseModel
 
-from app.config import settings
+from app.config import minimax_base_url, settings
 
 logger = logging.getLogger(__name__)
 
@@ -25,18 +25,20 @@ TIER_MODELS = {
         "anthropic": settings.synthesis_model,
         "openai": settings.openai_synthesis_model,
         "nebius": settings.nebius_synthesis_model,
+        "minimax": settings.minimax_synthesis_model,
     },
     "sentiment": {
         "anthropic": settings.sentiment_model,
         "openai": settings.openai_sentiment_model,
         "nebius": settings.nebius_sentiment_model,
+        "minimax": settings.minimax_sentiment_model,
     },
 }
 
 
 def _resolve_provider() -> str:
     p = (settings.llm_provider or "auto").lower()
-    if p in ("openai", "anthropic", "nebius"):
+    if p in ("openai", "anthropic", "nebius", "minimax"):
         return p
     return "anthropic" if settings.anthropic_api_key else "openai"
 
@@ -45,7 +47,7 @@ def _openai_compatible_parse(
     *, api_key: str, base_url: str | None, model: str,
     system: str, user_content: str, output_model: type[T], max_tokens: int,
 ) -> T | None:
-    """Shared path for OpenAI and any OpenAI-compatible endpoint (Nebius).
+    """Shared path for OpenAI and any OpenAI-compatible endpoint.
     Tries native structured outputs; falls back to JSON-object mode + manual
     validation for endpoints/models that don't support json_schema."""
     from openai import OpenAI
@@ -108,6 +110,39 @@ def parse_structured(
             **kwargs,
         )
         return response.parsed_output
+
+    if provider == "minimax":
+        if not settings.minimax_api_key:
+            raise RuntimeError("LLM_PROVIDER=minimax but MINIMAX_API_KEY is not set")
+        protocol = (settings.minimax_protocol or "openai").lower()
+        if protocol == "anthropic":
+            import anthropic
+
+            client = anthropic.Anthropic(
+                api_key=settings.minimax_api_key,
+                base_url=minimax_base_url("anthropic"),
+            )
+            kwargs = {"thinking": {"type": "adaptive"}} if tier == "synthesis" else {}
+            response = client.messages.parse(
+                model=models["minimax"],
+                max_tokens=max_tokens,
+                system=system,
+                messages=[{"role": "user", "content": user_content}],
+                output_format=output_model,
+                **kwargs,
+            )
+            return response.parsed_output
+        if protocol == "openai":
+            return _openai_compatible_parse(
+                api_key=settings.minimax_api_key,
+                base_url=minimax_base_url("openai"),
+                model=models["minimax"],
+                system=system,
+                user_content=user_content,
+                output_model=output_model,
+                max_tokens=max_tokens,
+            )
+        raise ValueError("MINIMAX_PROTOCOL must be openai or anthropic")
 
     if provider == "nebius":
         if not settings.nebius_api_key:


### PR DESCRIPTION
Reason: add MiniMax target models to the existing provider registries.

This change:
- Adds MiniMax-M3 for synthesis and MiniMax-M2.7 for sentiment.
- Adds selectable global_en and cn_zh regions with both supported request protocols and their regional endpoints.
- Documents environment variables, model defaults, endpoint behavior, and official API references.

Checks:
- uv pip install -e . --python .venv/bin/python in each backend
- uv pip install -e .[dev] --python .venv/bin/python in maintainer_brief/backend
- python -m compileall -q app in both backends
- pytest -q in maintainer_brief/backend; no tests were collected
- SDK request-path capture for both protocols
- git diff --check and secret scan