### PR TITLE
Add DexPaprika DeFi agent (mcp_ai_agents)

### DIFF
--- a/mcp_ai_agents/dexpaprika_defi_agent/.env.example
+++ b/mcp_ai_agents/dexpaprika_defi_agent/.env.example
@@ -1,5 +1,7 @@
-# OpenAI key for the agent's model. The DexPaprika MCP itself is keyless.
-OPENAI_API_KEY=sk-...
+# Nebius Token Factory key for the agent's model. The DexPaprika MCP is keyless.
+# Get one at https://tokenfactory.nebius.com/project/api-keys
+NEBIUS_API_KEY=...
 
-# Optional: pick a different OpenAI model (defaults to gpt-4o).
-# OPENAI_MODEL=gpt-4o-mini
+# Optional: pick a different Token Factory model (defaults to
+# Qwen/Qwen3-235B-A22B-Instruct-2507).
+# NEBIUS_MODEL=openai/gpt-oss-120b

--- a/mcp_ai_agents/dexpaprika_defi_agent/.env.example
+++ b/mcp_ai_agents/dexpaprika_defi_agent/.env.example
@@ -1,0 +1,5 @@
+# OpenAI key for the agent's model. The DexPaprika MCP itself is keyless.
+OPENAI_API_KEY=sk-...
+
+# Optional: pick a different OpenAI model (defaults to gpt-4o).
+# OPENAI_MODEL=gpt-4o-mini

--- a/mcp_ai_agents/dexpaprika_defi_agent/README.md
+++ b/mcp_ai_agents/dexpaprika_defi_agent/README.md
@@ -1,0 +1,93 @@
+# DexPaprika DeFi Agent
+
+> An agent that answers on-chain DEX questions (token prices, liquidity pools, OHLCV history) by calling the keyless DexPaprika MCP server.
+
+Ask it things like "what are the top WETH pools on Ethereum by volume?" or "what is PEPE trading at, and on which chain?" and it works out which DexPaprika tools to call and reads the answer back. DexPaprika's API is keyless, so the only credential you supply is your OpenAI key.
+
+## Features
+
+- **Keyless data source.** DexPaprika needs no API key or signup. The only credential in this project is your OpenAI key.
+- **Real DEX market data.** Token search, pool discovery, current prices, and OHLCV history across the chains DexPaprika covers.
+- **MCP over stdio.** The agent loads the DexPaprika MCP server (`npx dexpaprika-mcp`) as its toolset, so there is no custom tool wiring to maintain.
+- **Ask your own question.** Pass a question as a command-line argument, or run with no arguments for a default query.
+
+## Tech Stack
+
+- **Python** with `asyncio`
+- **LangChain / LangGraph** for the ReAct agent loop (`create_react_agent`)
+- **langchain-mcp-adapters** to load the MCP server's tools
+- **DexPaprika MCP** (`dexpaprika-mcp`, keyless) as the data source
+- **OpenAI** (`gpt-4o` by default) for the model
+
+## Workflow
+
+The agent opens one persistent connection to the DexPaprika MCP server over stdio, loads its tools, and runs a standard ReAct loop. It resolves a token name or symbol to a contract address with `search` first, then calls the pool and price tools, and writes a plain-language answer. Everything on the data side is keyless.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10+
+- [Node.js](https://nodejs.org) (the DexPaprika MCP server runs through `npx`)
+- An [OpenAI API key](https://platform.openai.com/api-keys)
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and add your key:
+
+```env
+OPENAI_API_KEY="your_openai_api_key"
+
+# Optional, defaults to gpt-4o:
+# OPENAI_MODEL="gpt-4o-mini"
+```
+
+The DexPaprika side needs nothing. The API is public and keyless.
+
+### Installation
+
+```bash
+git clone https://github.com/Arindam200/awesome-ai-apps.git
+cd awesome-ai-apps/mcp_ai_agents/dexpaprika_defi_agent
+
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the default question:
+
+```bash
+python main.py
+```
+
+Or ask your own:
+
+```bash
+python main.py "Which DEX has the most liquid WETH/USDC pool on Ethereum, and what is its 24h volume?"
+```
+
+Sample run:
+
+```
+Question: What are the top 3 WETH liquidity pools on Ethereum by 24h volume, and what DEX is each on? Also give WETH's current USD price.
+
+(agent made 2 DexPaprika tool call(s))
+
+The top 3 WETH liquidity pools on Ethereum by 24h volume are all on Uniswap V3:
+1. Uniswap V3, WETH/USDC, 24h volume $81,784,150.62
+2. Uniswap V3, WETH/USDC, 24h volume $38,008,827.56
+3. Uniswap V3, WETH/USDT, 24h volume $30,798,091.80
+WETH's current price is about $1,879.71.
+```
+
+The first run downloads the DexPaprika MCP server through `npx`, so give it a few extra seconds.
+
+## Notes
+
+- The MCP server is pinned to `@latest` so `npx` never serves a stale cached build.
+- `gpt-4o-mini` works and is cheaper, but I found `gpt-4o` more reliable on multi-step pool queries. Set `OPENAI_MODEL` to switch.
+- More on the data source: [DexPaprika API docs](https://docs.dexpaprika.com) and the [MCP server](https://github.com/coinpaprika/dexpaprika-mcp).

--- a/mcp_ai_agents/dexpaprika_defi_agent/README.md
+++ b/mcp_ai_agents/dexpaprika_defi_agent/README.md
@@ -2,11 +2,11 @@
 
 > An agent that answers on-chain DEX questions (token prices, liquidity pools, OHLCV history) by calling the keyless DexPaprika MCP server.
 
-Ask it things like "what are the top WETH pools on Ethereum by volume?" or "what is PEPE trading at, and on which chain?" and it works out which DexPaprika tools to call and reads the answer back. DexPaprika's API is keyless, so the only credential you supply is your OpenAI key.
+Ask it things like "what are the top WETH pools on Ethereum by volume?" or "what is PEPE trading at, and on which chain?" and it works out which DexPaprika tools to call and reads the answer back. DexPaprika's API is keyless, so the only credential you supply is your Nebius key.
 
 ## Features
 
-- **Keyless data source.** DexPaprika needs no API key or signup. The only credential in this project is your OpenAI key.
+- **Keyless data source.** DexPaprika needs no API key or signup. The only credential in this project is your Nebius key.
 - **Real DEX market data.** Token search, pool discovery, current prices, and OHLCV history across the chains DexPaprika covers.
 - **MCP over stdio.** The agent loads the DexPaprika MCP server (`npx dexpaprika-mcp`) as its toolset, so there is no custom tool wiring to maintain.
 - **Ask your own question.** Pass a question as a command-line argument, or run with no arguments for a default query.
@@ -17,7 +17,7 @@ Ask it things like "what are the top WETH pools on Ethereum by volume?" or "what
 - **LangChain / LangGraph** for the ReAct agent loop (`create_react_agent`)
 - **langchain-mcp-adapters** to load the MCP server's tools
 - **DexPaprika MCP** (`dexpaprika-mcp`, keyless) as the data source
-- **OpenAI** (`gpt-4o` by default) for the model
+- **Nebius Token Factory** (`Qwen/Qwen3-235B-A22B-Instruct-2507` by default) for the model
 
 ## Workflow
 
@@ -29,17 +29,17 @@ The agent opens one persistent connection to the DexPaprika MCP server over stdi
 
 - Python 3.10+
 - [Node.js](https://nodejs.org) (the DexPaprika MCP server runs through `npx`)
-- An [OpenAI API key](https://platform.openai.com/api-keys)
+- A [Nebius Token Factory API key](https://tokenfactory.nebius.com/project/api-keys)
 
 ### Environment Variables
 
 Copy `.env.example` to `.env` and add your key:
 
 ```env
-OPENAI_API_KEY="your_openai_api_key"
+NEBIUS_API_KEY="your_nebius_api_key"
 
-# Optional, defaults to gpt-4o:
-# OPENAI_MODEL="gpt-4o-mini"
+# Optional, defaults to Qwen/Qwen3-235B-A22B-Instruct-2507:
+# NEBIUS_MODEL="openai/gpt-oss-120b"
 ```
 
 The DexPaprika side needs nothing. The API is public and keyless.
@@ -75,19 +75,21 @@ Sample run:
 ```
 Question: What are the top 3 WETH liquidity pools on Ethereum by 24h volume, and what DEX is each on? Also give WETH's current USD price.
 
-(agent made 2 DexPaprika tool call(s))
+(agent made 3 DexPaprika tool call(s))
 
-The top 3 WETH liquidity pools on Ethereum by 24h volume are all on Uniswap V3:
-1. Uniswap V3, WETH/USDC, 24h volume $81,784,150.62
-2. Uniswap V3, WETH/USDC, 24h volume $38,008,827.56
-3. Uniswap V3, WETH/USDT, 24h volume $30,798,091.80
-WETH's current price is about $1,879.71.
+The top 3 WETH liquidity pools on Ethereum by 24h volume are:
+1. Uniswap V3, WETH/USDC 0.05%, 24h volume $115,546,896.64
+2. Uniswap V3, WETH/USDC 0.3%, 24h volume $30,334,025.60
+3. Curve, WETH/stETH, 24h volume $14,129,442.68
+WETH's current price is about $1,922.39.
 ```
+
+(Numbers are live, so your run will differ.)
 
 The first run downloads the DexPaprika MCP server through `npx`, so give it a few extra seconds.
 
 ## Notes
 
 - The MCP server is pinned to `@latest` so `npx` never serves a stale cached build.
-- `gpt-4o-mini` works and is cheaper, but I found `gpt-4o` more reliable on multi-step pool queries. Set `OPENAI_MODEL` to switch.
+- A large, capable model handles the multi-step pool queries reliably. Very small models sometimes send numeric arguments (like a result limit) as strings, which the MCP rejects, so they can stall. `openai/gpt-oss-120b` is a good lighter alternative; set `NEBIUS_MODEL` to switch.
 - More on the data source: [DexPaprika API docs](https://docs.dexpaprika.com) and the [MCP server](https://github.com/coinpaprika/dexpaprika-mcp).

--- a/mcp_ai_agents/dexpaprika_defi_agent/main.py
+++ b/mcp_ai_agents/dexpaprika_defi_agent/main.py
@@ -1,0 +1,90 @@
+"""DexPaprika DeFi agent.
+
+A LangChain agent that answers on-chain DEX questions (token prices, liquidity
+pools, OHLCV history) by calling the DexPaprika MCP server. The DexPaprika API
+is keyless, so the only credential you need is your LLM provider key.
+"""
+
+import asyncio
+import logging
+import os
+import sys
+import warnings
+
+from dotenv import load_dotenv
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+load_dotenv()
+
+# create_react_agent is being renamed to langchain.agents.create_agent; the
+# prebuilt helper still works and is the clearest fit for this example.
+warnings.filterwarnings("ignore", message="create_react_agent has been moved")
+
+# The DexPaprika MCP server prints a startup banner before the JSON-RPC
+# handshake; the stdio client logs a harmless parse warning for it. Silence that
+# so the demo output stays clean.
+logging.getLogger("mcp.client.stdio").setLevel(logging.CRITICAL)
+
+SYSTEM_PROMPT = (
+    "You are a DeFi market-data assistant backed by the DexPaprika tools "
+    "(on-chain DEX prices, liquidity pools, and OHLCV history).\n\n"
+    "Rules:\n"
+    "1. To look up a token by name or symbol (e.g. 'WETH', 'USDC'), FIRST call "
+    "`search`. The token and pool tools require the on-chain contract address, "
+    "not the symbol. In each search result, the token's `id` is the contract "
+    "address and `chain` is the network id.\n"
+    "2. Then call getTokenPools with that contract address and network to list "
+    "its pools.\n"
+    "3. For 'most liquid' or 'most active', rank by 24h volume (`volume_usd_24h`), "
+    "not raw liquidity: a pool with huge reported liquidity but near-zero volume "
+    "is inactive or malformed, so skip it.\n"
+    "4. Cite the DEX name and the exact numbers you retrieved. Never invent values."
+)
+
+DEFAULT_QUESTION = (
+    "What are the top 3 WETH liquidity pools on Ethereum by 24h volume, "
+    "and what DEX is each on? Also give WETH's current USD price."
+)
+
+
+async def main() -> None:
+    question = " ".join(sys.argv[1:]).strip() or DEFAULT_QUESTION
+
+    # The keyless DexPaprika MCP server over stdio (needs Node.js). Pinning
+    # @latest keeps a stale npx cache from serving an old build.
+    client = MultiServerMCPClient(
+        {
+            "dexpaprika": {
+                "command": "npx",
+                "args": ["-y", "dexpaprika-mcp@latest"],
+                "transport": "stdio",
+            }
+        }
+    )
+
+    # Keep one MCP server alive for the whole run instead of spawning a fresh
+    # process on every tool call.
+    async with client.session("dexpaprika") as session:
+        tools = await load_mcp_tools(session)
+        # gpt-4o handles the multi-step tool use reliably; set OPENAI_MODEL to a
+        # cheaper model (e.g. gpt-4o-mini) if you prefer.
+        model = ChatOpenAI(model=os.environ.get("OPENAI_MODEL", "gpt-4o"), temperature=0)
+        agent = create_react_agent(model, tools, prompt=SYSTEM_PROMPT)
+        result = await agent.ainvoke(
+            {"messages": [{"role": "user", "content": question}]},
+            {"recursion_limit": 15},
+        )
+
+    tool_calls = sum(
+        len(getattr(m, "tool_calls", []) or []) for m in result["messages"]
+    )
+    print(f"\nQuestion: {question}\n")
+    print(f"(agent made {tool_calls} DexPaprika tool call(s))\n")
+    print(result["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_ai_agents/dexpaprika_defi_agent/main.py
+++ b/mcp_ai_agents/dexpaprika_defi_agent/main.py
@@ -14,7 +14,7 @@ import warnings
 from dotenv import load_dotenv
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
-from langchain_openai import ChatOpenAI
+from langchain_nebius import ChatNebius
 from langgraph.prebuilt import create_react_agent
 
 load_dotenv()
@@ -69,9 +69,14 @@ async def main() -> None:
     # process on every tool call.
     async with client.session("dexpaprika") as session:
         tools = await load_mcp_tools(session)
-        # gpt-4o handles the multi-step tool use reliably; set OPENAI_MODEL to a
-        # cheaper model (e.g. gpt-4o-mini) if you prefer.
-        model = ChatOpenAI(model=os.environ.get("OPENAI_MODEL", "gpt-4o"), temperature=0)
+        # A large, capable model handles the multi-step tool use reliably. Very
+        # small models sometimes send numeric arguments as strings and stall, so
+        # this defaults to a strong one; set NEBIUS_MODEL to switch (for example
+        # openai/gpt-oss-120b also works well).
+        model = ChatNebius(
+            model=os.environ.get("NEBIUS_MODEL", "Qwen/Qwen3-235B-A22B-Instruct-2507"),
+            temperature=0,
+        )
         agent = create_react_agent(model, tools, prompt=SYSTEM_PROMPT)
         result = await agent.ainvoke(
             {"messages": [{"role": "user", "content": question}]},

--- a/mcp_ai_agents/dexpaprika_defi_agent/requirements.txt
+++ b/mcp_ai_agents/dexpaprika_defi_agent/requirements.txt
@@ -1,0 +1,5 @@
+langchain==1.3.14
+langchain-openai==1.3.5
+langchain-mcp-adapters==0.3.0
+langgraph==1.2.9
+python-dotenv==1.2.2

--- a/mcp_ai_agents/dexpaprika_defi_agent/requirements.txt
+++ b/mcp_ai_agents/dexpaprika_defi_agent/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.14
-langchain-openai==1.3.5
+langchain-nebius==0.1.3
 langchain-mcp-adapters==0.3.0
 langgraph==1.2.9
 python-dotenv==1.2.2


### PR DESCRIPTION
This adds a DexPaprika DeFi agent under `mcp_ai_agents/`, per #252.

It's a LangGraph ReAct agent that answers on-chain DEX questions by loading the DexPaprika MCP server as its toolset. You ask something like "top WETH pools on Ethereum by 24h volume" or "what is PEPE trading at, and on which chain?", and it resolves the token, calls the pool/price/OHLCV tools, and reads the answer back. DexPaprika is keyless, so the only credential is an OpenAI key.

Files (`mcp_ai_agents/dexpaprika_defi_agent/`):

- `main.py`: the agent (one persistent MCP session, ReAct loop, question via a CLI arg or a default)
- `README.md`: from the template, with setup and a sample run
- `requirements.txt`: pinned
- `.env.example`

I ran it end to end against the live DexPaprika MCP and OpenAI before opening this, so the sample output in the README is a real run. It uses `gpt-4o` by default (I found it more reliable than mini on multi-step pool queries), overridable via `OPENAI_MODEL`.

Closes #252.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a DexPaprika DeFi agent that answers on-chain DEX questions (token prices, pools, OHLCV) using tool-driven workflows and volume-based ranking.
  - Added configurable Nebius model selection via environment variable, with a defined default model.
- **Documentation**
  - Added/expanded README covering installation, setup, end-to-end workflow, CLI usage, and a sample run transcript.
  - Documented required and optional environment settings, including that the DexPaprika MCP is keyless.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->