### PR TITLE
Add Darkmoon - GPL-3.0 AI pentest platform / MCP host

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Interested in sponsoring this project? Feel free to reach out!
 
 ### 🎓 Course Playlists
 
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source autonomous pentest engine (GPL-3.0): AD + Kubernetes + web, evidence trail on every finding, runs on local or hosted models.
 - [**AWS Strands Course**](https://www.youtube.com/playlist?list=PLMZM1DAlf0Lrc43ZtUXAwYu9DhnqxzRKZ): Complete 8-lesson course on building AI agents with AWS Strands SDK
 
 ### 🔧 Framework Tutorials


### PR DESCRIPTION
Hi, thanks for maintaining this list. Adding Darkmoon, a GPL-3.0 autonomous penetration testing platform covering Active Directory and Kubernetes alongside web and APIs. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: our project. Happy to adjust or close if not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Darkmoon project to the Course Playlists section, including its repository link and a brief description of its capabilities and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->