### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,4 +465,4 @@ For any questions, suggestions, or contributions, feel free to reach out to the 
 
 ## Thank You for the Support! 🙏
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Arindam200/awesome-ai-apps&type=Date)](https://www.star-history.com/#Arindam200/awesome-ai-apps&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Arindam200/awesome-ai-apps&type=Date)](https://star-history.dera.page/#Arindam200/awesome-ai-apps&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This update moves it to star-history.dera.page, which uses a different data source requiring no API token, so the chart renders reliably for everyone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use the new Star History website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->