### PR TITLE
Add a human-gated PydanticAI coding harness starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ Interested in sponsoring this project? Feel free to reach out!
 
 ### 🧩 Starter Agents
 
-**Quick-start agents for learning and extending different AI frameworks.** _20 projects_
+**Quick-start agents for learning and extending different AI frameworks.** _21 projects_
 
 - [AutoGen Tool-Calling Starter](starter_ai_agents/autogen_starter): Microsoft AutoGen `AssistantAgent` with a custom tool, powered by Nebius Token Factory
 - [AWS Strands Agent Starter](starter_ai_agents/aws_strands_starter): Weather report agent using AWS Strands SDK
 - [CAMEL AI Model Benchmark](starter_ai_agents/camel_ai_starter): Performance benchmarking tool comparing various AI models
+- [Coding Harness Starter](starter_ai_agents/coding_harness_starter): PydanticAI coding loop with structured patch proposals, human-gated file writes, and allowlisted pytest execution
 - [CrewAI Research Crew](starter_ai_agents/crewai_starter): Multi-agent research team example
 - [Docker cagent Multi-Agent Starter](starter_ai_agents/cagent_starter): Open-source customizable multi-agent runtime by Docker
 - [DSPy Optimization Starter](starter_ai_agents/dspy_starter): DSPy framework for building and optimizing AI systems

--- a/starter_ai_agents/coding_harness_starter/.env.example
+++ b/starter_ai_agents/coding_harness_starter/.env.example
@@ -1,0 +1,2 @@
+NEBIUS_API_KEY="your_nebius_token_factory_api_key"
+NEBIUS_MODEL="Qwen/Qwen3-30B-A3B"

--- a/starter_ai_agents/coding_harness_starter/README.md
+++ b/starter_ai_agents/coding_harness_starter/README.md
@@ -1,0 +1,166 @@
+# Coding Harness Starter
+
+> A compact PydanticAI example that inspects a repository, proposes a patch,
+> waits for human approval, applies approved changes, and runs a fixed test command.
+
+This starter demonstrates a complete coding-agent development loop without a
+multi-agent graph, remote sandbox, or web UI. The language model receives only
+read-only tools. Application code owns the approval, write, and test boundaries.
+
+## 🚀 Features
+
+- **Repository inspection**: `list_files` and `read_file` are scoped to one workspace.
+- **Structured plan and patch**: Pydantic validates the agent's `ChangeProposal`.
+- **Human-in-the-loop gate**: no file is written until the user enters `y` or `yes`.
+- **Reviewable diff**: unified diffs are rendered before the approval prompt.
+- **Allowlisted testing**: the harness runs only `python -m pytest -q`, without a shell.
+- **Machine-readable result**: the proposal and final summary are printed as JSON.
+
+## 🛠️ Tech Stack
+
+- Python 3.10+
+- [PydanticAI](https://ai.pydantic.dev/) for the typed agent and read-only tools
+- [Nebius Token Factory](https://dub.sh/nebius) for OpenAI-compatible inference
+- pytest for the fixture repository and workspace-boundary tests
+
+## Workflow
+
+```text
+Task
+  ↓
+Inspect workspace (read-only tools)
+  ↓
+Structured plan + file proposal
+  ↓
+Render unified diff
+  ↓
+Human approval ── reject ──▶ stop without writes
+  ↓ approve
+Apply files inside workspace
+  ↓
+Run fixed pytest command
+  ↓
+JSON summary
+```
+
+The included fixture repository has a deliberately broken `calculator.add`
+implementation. The default task asks the agent to repair it and verify the fix.
+
+## 📦 Getting Started
+
+### Prerequisites
+
+- Python 3.10 or newer
+- [uv](https://docs.astral.sh/uv/) or pip
+- A Nebius Token Factory API key
+
+### Environment Variables
+
+Copy the example configuration and add your key:
+
+```bash
+cp .env.example .env
+```
+
+```env
+NEBIUS_API_KEY="your_nebius_token_factory_api_key"
+NEBIUS_MODEL="Qwen/Qwen3-30B-A3B"
+```
+
+Never commit the populated `.env` file.
+
+### Installation
+
+```bash
+cd starter_ai_agents/coding_harness_starter
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+With uv:
+
+```bash
+uv sync --extra dev
+```
+
+## ⚙️ Usage
+
+Run the seeded repair task:
+
+```bash
+uv run python main.py
+```
+
+Or provide another small coding task and workspace:
+
+```bash
+uv run python main.py "Add type hints to calculator.py" --workspace fixture_repo
+```
+
+The harness first prints the structured proposal and unified diff. Review them,
+then enter `y` to approve. Any other response stops the run without writing files.
+
+Run the harness safety tests without making an LLM request:
+
+```bash
+uv run pytest tests -q
+```
+
+Reset the deliberately broken fixture after a successful demo:
+
+```bash
+git restore fixture_repo/calculator.py
+```
+
+## Safety Boundaries
+
+- All requested paths are resolved against the configured workspace. Absolute
+  paths, `..` traversal, and symlinks that resolve outside the workspace fail.
+- `.env`, `.git`, virtual-environment, and cache paths are never exposed through
+  the inspection tools, including aliases created with symbolic links.
+- The PydanticAI agent receives no write or shell tool. It can only return a
+  structured proposal.
+- `Workspace.apply_changes()` requires `approved=True`; the CLI supplies it only
+  after an explicit `y` or `yes` response.
+- Every proposed path is validated before the first file is written.
+- Tests use a constant argument list and `shell=False`. The model cannot select or
+  modify the command.
+- File reads are capped at 50 KB to keep this educational starter bounded.
+
+This is a local workspace boundary, not an operating-system sandbox. For
+untrusted repositories or commands, use a container or dedicated sandbox service.
+
+## 📂 Project Structure
+
+```text
+coding_harness_starter/
+├── agent.py                 # PydanticAI agent; read-only tools only
+├── main.py                  # CLI workflow and approval prompt
+├── models.py                # Structured proposal and result models
+├── tools.py                 # list_files and read_file tools
+├── workspace.py             # path boundary, writes, diff, fixed test runner
+├── fixture_repo/
+│   ├── calculator.py        # deliberately broken sample code
+│   └── test_calculator.py   # sample repository tests
+├── tests/
+│   ├── test_agent.py        # offline structured-agent test
+│   └── test_workspace.py    # boundary, approval, and test-loop tests
+├── .env.example
+├── pyproject.toml
+└── README.md
+```
+
+## 🤝 Contributing
+
+Contributions are welcome. See the repository's
+[CONTRIBUTING.md](../../CONTRIBUTING.md) for the project and pull-request rules.
+
+## 📄 License
+
+This example follows the license of the parent Awesome AI Apps repository.
+
+## 🙏 Acknowledgments
+
+- [PydanticAI](https://ai.pydantic.dev/) for typed agents and dependency-injected tools
+- [Nebius Token Factory](https://dub.sh/nebius) for model inference

--- a/starter_ai_agents/coding_harness_starter/README.md
+++ b/starter_ai_agents/coding_harness_starter/README.md
@@ -124,9 +124,12 @@ git restore fixture_repo/calculator.py
 - `Workspace.apply_changes()` requires `approved=True`; the CLI supplies it only
   after an explicit `y` or `yes` response.
 - Every proposed path is validated before the first file is written.
+- A failed multi-file apply restores earlier files, avoiding a partially applied patch.
 - Tests use a constant argument list and `shell=False`. The model cannot select or
   modify the command.
 - File reads are capped at 50 KB to keep this educational starter bounded.
+- Invalid proposals and test timeouts produce the same structured run-summary shape
+  as successful and rejected runs.
 
 This is a local workspace boundary, not an operating-system sandbox. For
 untrusted repositories or commands, use a container or dedicated sandbox service.

--- a/starter_ai_agents/coding_harness_starter/agent.py
+++ b/starter_ai_agents/coding_harness_starter/agent.py
@@ -1,0 +1,44 @@
+"""PydanticAI coding agent that can inspect files but cannot write them."""
+
+from __future__ import annotations
+
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from models import ChangeProposal
+from tools import AgentDependencies, list_files, read_file
+
+DEFAULT_MODEL = "Qwen/Qwen3-30B-A3B"
+NEBIUS_BASE_URL = "https://api.tokenfactory.nebius.com/v1"
+
+INSTRUCTIONS = """You are a careful coding agent working on a tiny repository.
+Always call list_files first, then read every relevant file before proposing a change.
+Return a short plan and the smallest complete-file replacement that solves the task.
+Use only workspace-relative paths. Do not change tests unless the task explicitly asks
+for a test change. You have no write or shell tools: your output is only a proposal
+that a human will review before the application may modify any file.
+"""
+
+
+def build_agent() -> Agent[AgentDependencies, ChangeProposal]:
+    """Create the agent using Nebius' OpenAI-compatible endpoint."""
+    api_key = os.getenv("NEBIUS_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "NEBIUS_API_KEY is missing. Copy .env.example to .env and add your key."
+        )
+
+    model = OpenAIChatModel(
+        model_name=os.getenv("NEBIUS_MODEL", DEFAULT_MODEL),
+        provider=OpenAIProvider(base_url=NEBIUS_BASE_URL, api_key=api_key),
+    )
+    return Agent(
+        model=model,
+        deps_type=AgentDependencies,
+        output_type=ChangeProposal,
+        tools=[list_files, read_file],
+        instructions=INSTRUCTIONS,
+    )

--- a/starter_ai_agents/coding_harness_starter/fixture_repo/calculator.py
+++ b/starter_ai_agents/coding_harness_starter/fixture_repo/calculator.py
@@ -1,0 +1,6 @@
+"""A deliberately tiny module for the coding harness to repair."""
+
+
+def add(left: int, right: int) -> int:
+    """Return the sum of two integers."""
+    return left - right

--- a/starter_ai_agents/coding_harness_starter/fixture_repo/test_calculator.py
+++ b/starter_ai_agents/coding_harness_starter/fixture_repo/test_calculator.py
@@ -1,0 +1,9 @@
+from calculator import add
+
+
+def test_adds_two_integers() -> None:
+    assert add(2, 3) == 5
+
+
+def test_adds_negative_integer() -> None:
+    assert add(7, -2) == 5

--- a/starter_ai_agents/coding_harness_starter/fixture_repo/test_calculator.py
+++ b/starter_ai_agents/coding_harness_starter/fixture_repo/test_calculator.py
@@ -2,8 +2,10 @@ from calculator import add
 
 
 def test_adds_two_integers() -> None:
+    """Addition combines two positive integers."""
     assert add(2, 3) == 5
 
 
 def test_adds_negative_integer() -> None:
+    """Addition supports a negative right operand."""
     assert add(7, -2) == 5

--- a/starter_ai_agents/coding_harness_starter/main.py
+++ b/starter_ai_agents/coding_harness_starter/main.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from agent import build_agent
-from models import RunSummary
+from models import FileChange, RunSummary
 from tools import AgentDependencies
-from workspace import Workspace
+from workspace import Workspace, WorkspaceViolation
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEFAULT_WORKSPACE = PROJECT_ROOT / "fixture_repo"
@@ -37,6 +37,27 @@ def approved_by_human(answer: str) -> bool:
     return answer.strip().lower() in {"y", "yes"}
 
 
+def emit_summary(summary: RunSummary) -> None:
+    """Print the final result using the same JSON shape on every path."""
+    print("\n=== RUN SUMMARY ===")
+    print(json.dumps(summary.model_dump(), indent=2))
+
+
+def preview_changes(workspace: Workspace, changes: list[FileChange]) -> bool:
+    """Validate and render every diff before asking for approval."""
+    try:
+        previews = [(change, workspace.preview_diff(change)) for change in changes]
+    except WorkspaceViolation as exc:
+        emit_summary(RunSummary(status="invalid_proposal", error=str(exc)))
+        return False
+
+    print("\n=== PATCH PREVIEW ===")
+    for change, diff in previews:
+        print(f"\n# {change.path}: {change.reason}")
+        print(diff or "(no changes)")
+    return True
+
+
 def main() -> int:
     """Run inspect, propose, approve, apply, test, and summarize."""
     load_dotenv(PROJECT_ROOT / ".env")
@@ -49,27 +70,26 @@ def main() -> int:
 
     print("\n=== STRUCTURED PROPOSAL ===")
     print(proposal.model_dump_json(indent=2))
-    print("\n=== PATCH PREVIEW ===")
-    for change in proposal.changes:
-        print(f"\n# {change.path}: {change.reason}")
-        print(workspace.preview_diff(change) or "(no changes)")
+    if not preview_changes(workspace, proposal.changes):
+        return 1
 
     answer = input("\nApply these changes and run the allowlisted tests? [y/N] ")
     if not approved_by_human(answer):
-        summary = RunSummary(status="rejected")
-        print("\n=== RUN SUMMARY ===")
-        print(summary.model_dump_json(indent=2))
+        emit_summary(RunSummary(status="rejected"))
         return 0
 
-    changed_files = workspace.apply_changes(proposal.changes, approved=True)
+    try:
+        changed_files = workspace.apply_changes(proposal.changes, approved=True)
+    except WorkspaceViolation as exc:
+        emit_summary(RunSummary(status="apply_failed", error=str(exc)))
+        return 1
     test_result = workspace.run_tests()
     summary = RunSummary(
         status="passed" if test_result.passed else "tests_failed",
         changed_files=changed_files,
         tests=test_result,
     )
-    print("\n=== RUN SUMMARY ===")
-    print(json.dumps(summary.model_dump(), indent=2))
+    emit_summary(summary)
     return 0 if test_result.passed else 1
 
 

--- a/starter_ai_agents/coding_harness_starter/main.py
+++ b/starter_ai_agents/coding_harness_starter/main.py
@@ -46,6 +46,7 @@ def emit_summary(summary: RunSummary) -> None:
 def preview_changes(workspace: Workspace, changes: list[FileChange]) -> bool:
     """Validate and render every diff before asking for approval."""
     try:
+        workspace.validate_changes(changes)
         previews = [(change, workspace.preview_diff(change)) for change in changes]
     except WorkspaceViolation as exc:
         emit_summary(RunSummary(status="invalid_proposal", error=str(exc)))

--- a/starter_ai_agents/coding_harness_starter/main.py
+++ b/starter_ai_agents/coding_harness_starter/main.py
@@ -1,0 +1,77 @@
+"""Command-line entry point for the minimal coding harness."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from agent import build_agent
+from models import RunSummary
+from tools import AgentDependencies
+from workspace import Workspace
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_WORKSPACE = PROJECT_ROOT / "fixture_repo"
+DEFAULT_TASK = "Fix the bug in calculator.add so the repository tests pass."
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the coding task and optional workspace path."""
+    parser = argparse.ArgumentParser(description="Run a human-gated coding agent.")
+    parser.add_argument("task", nargs="?", default=DEFAULT_TASK)
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=DEFAULT_WORKSPACE,
+        help="Repository directory the agent may inspect and edit.",
+    )
+    return parser.parse_args()
+
+
+def approved_by_human(answer: str) -> bool:
+    """Accept only an unambiguous affirmative approval."""
+    return answer.strip().lower() in {"y", "yes"}
+
+
+def main() -> int:
+    """Run inspect, propose, approve, apply, test, and summarize."""
+    load_dotenv(PROJECT_ROOT / ".env")
+    args = parse_args()
+    workspace = Workspace(args.workspace)
+    agent = build_agent()
+
+    result = asyncio.run(agent.run(args.task, deps=AgentDependencies(workspace)))
+    proposal = result.output
+
+    print("\n=== STRUCTURED PROPOSAL ===")
+    print(proposal.model_dump_json(indent=2))
+    print("\n=== PATCH PREVIEW ===")
+    for change in proposal.changes:
+        print(f"\n# {change.path}: {change.reason}")
+        print(workspace.preview_diff(change) or "(no changes)")
+
+    answer = input("\nApply these changes and run the allowlisted tests? [y/N] ")
+    if not approved_by_human(answer):
+        summary = RunSummary(status="rejected")
+        print("\n=== RUN SUMMARY ===")
+        print(summary.model_dump_json(indent=2))
+        return 0
+
+    changed_files = workspace.apply_changes(proposal.changes, approved=True)
+    test_result = workspace.run_tests()
+    summary = RunSummary(
+        status="passed" if test_result.passed else "tests_failed",
+        changed_files=changed_files,
+        tests=test_result,
+    )
+    print("\n=== RUN SUMMARY ===")
+    print(json.dumps(summary.model_dump(), indent=2))
+    return 0 if test_result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starter_ai_agents/coding_harness_starter/models.py
+++ b/starter_ai_agents/coding_harness_starter/models.py
@@ -31,6 +31,7 @@ class TestResult(BaseModel):
 
     @property
     def passed(self) -> bool:
+        """Return whether pytest exited successfully."""
         return self.returncode == 0
 
 
@@ -40,3 +41,4 @@ class RunSummary(BaseModel):
     status: str
     changed_files: list[str] = Field(default_factory=list)
     tests: TestResult | None = None
+    error: str | None = None

--- a/starter_ai_agents/coding_harness_starter/models.py
+++ b/starter_ai_agents/coding_harness_starter/models.py
@@ -1,0 +1,42 @@
+"""Structured data exchanged by the coding harness."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class FileChange(BaseModel):
+    """A complete replacement proposed for one workspace file."""
+
+    path: str = Field(description="Path relative to the configured workspace root")
+    new_content: str = Field(description="Complete new contents for the file")
+    reason: str = Field(description="Short explanation of why the change is needed")
+
+
+class ChangeProposal(BaseModel):
+    """The agent's human-reviewable plan and proposed changes."""
+
+    plan: list[str] = Field(min_length=1, max_length=6)
+    changes: list[FileChange] = Field(min_length=1, max_length=5)
+    summary: str
+
+
+class TestResult(BaseModel):
+    """Result of the one allowlisted test command."""
+
+    command: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def passed(self) -> bool:
+        return self.returncode == 0
+
+
+class RunSummary(BaseModel):
+    """Final machine-readable harness result."""
+
+    status: str
+    changed_files: list[str] = Field(default_factory=list)
+    tests: TestResult | None = None

--- a/starter_ai_agents/coding_harness_starter/pyproject.toml
+++ b/starter_ai_agents/coding_harness_starter/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "coding-harness-starter"
+version = "0.1.0"
+description = "Minimal PydanticAI coding harness with human-gated file writes"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic-ai-slim[openai]>=2.37.0,<3.0.0",
+    "pytest>=8.0,<9.0",
+    "python-dotenv>=1.0.1,<2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.8",
+]
+
+[tool.ruff]
+line-length = 88
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/starter_ai_agents/coding_harness_starter/pyproject.toml
+++ b/starter_ai_agents/coding_harness_starter/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "coding-harness-starter"
+name = "coding_harness_starter"
 version = "0.1.0"
 description = "Minimal PydanticAI coding harness with human-gated file writes"
 readme = "README.md"

--- a/starter_ai_agents/coding_harness_starter/tests/test_agent.py
+++ b/starter_ai_agents/coding_harness_starter/tests/test_agent.py
@@ -15,6 +15,7 @@ models.ALLOW_MODEL_REQUESTS = False
 def test_agent_tools_and_structured_output_without_network(
     tmp_path: Path, monkeypatch
 ) -> None:
+    """The real agent wiring produces validated output with a test model."""
     (tmp_path / "calculator.py").write_text(
         "def add(left, right):\n    return left - right\n", encoding="utf-8"
     )

--- a/starter_ai_agents/coding_harness_starter/tests/test_agent.py
+++ b/starter_ai_agents/coding_harness_starter/tests/test_agent.py
@@ -1,0 +1,33 @@
+import asyncio
+from pathlib import Path
+
+from pydantic_ai import models
+from pydantic_ai.models.test import TestModel
+
+from agent import build_agent
+from models import ChangeProposal
+from tools import AgentDependencies
+from workspace import Workspace
+
+models.ALLOW_MODEL_REQUESTS = False
+
+
+def test_agent_tools_and_structured_output_without_network(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / "calculator.py").write_text(
+        "def add(left, right):\n    return left - right\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("NEBIUS_API_KEY", "test-key")
+    agent = build_agent()
+
+    with agent.override(model=TestModel(call_tools="all")):
+        result = asyncio.run(
+            agent.run(
+                "Fix calculator.add.", deps=AgentDependencies(Workspace(tmp_path))
+            )
+        )
+
+    assert isinstance(result.output, ChangeProposal)
+    assert result.output.plan
+    assert result.output.changes

--- a/starter_ai_agents/coding_harness_starter/tests/test_workspace.py
+++ b/starter_ai_agents/coding_harness_starter/tests/test_workspace.py
@@ -97,6 +97,30 @@ def test_rolls_back_an_incomplete_multi_file_change(tmp_path: Path) -> None:
     assert first.read_text(encoding="utf-8") == "original\n"
 
 
+def test_failed_batch_removes_new_parent_directories(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Rollback removes empty parent directories created by the batch."""
+    original_write_text = Path.write_text
+
+    def fail_second_write(path: Path, *args, **kwargs):
+        """Simulate an I/O failure after the first file is written."""
+        if path.name == "second.py":
+            raise OSError("simulated write failure")
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_second_write)
+    workspace = Workspace(tmp_path)
+
+    with pytest.raises(WorkspaceViolation, match="Could not apply"):
+        workspace.apply_changes(
+            [change("new/nested/first.py"), change("second.py")], approved=True
+        )
+
+    assert not (tmp_path / "new").exists()
+    assert not (tmp_path / "second.py").exists()
+
+
 def test_rejects_non_utf8_files(tmp_path: Path) -> None:
     """Binary data becomes a recoverable workspace violation."""
     (tmp_path / "binary.dat").write_bytes(b"\xff\xfe")
@@ -130,6 +154,32 @@ def test_invalid_preview_emits_a_structured_summary(tmp_path: Path, capsys) -> N
     output = capsys.readouterr().out
     assert '"status": "invalid_proposal"' in output
     assert '"error":' in output
+
+
+def test_preview_rejects_duplicate_paths(tmp_path: Path, capsys) -> None:
+    """Duplicate targets are rejected before any diff is rendered."""
+    rendered = preview_changes(
+        Workspace(tmp_path), [change("same.py"), change("same.py")]
+    )
+
+    assert not rendered
+    output = capsys.readouterr().out
+    assert '"status": "invalid_proposal"' in output
+    assert "Duplicate change" in output
+    assert "PATCH PREVIEW" not in output
+
+
+def test_preview_rejects_directory_target(tmp_path: Path, capsys) -> None:
+    """Existing directories cannot reach the approval prompt as file targets."""
+    (tmp_path / "package").mkdir()
+
+    rendered = preview_changes(Workspace(tmp_path), [change("package")])
+
+    assert not rendered
+    output = capsys.readouterr().out
+    assert '"status": "invalid_proposal"' in output
+    assert "Target is not a file" in output
+    assert "PATCH PREVIEW" not in output
 
 
 def test_runs_only_the_predefined_pytest_command(tmp_path: Path) -> None:

--- a/starter_ai_agents/coding_harness_starter/tests/test_workspace.py
+++ b/starter_ai_agents/coding_harness_starter/tests/test_workspace.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from main import approved_by_human
+from models import FileChange
+from workspace import ALLOWED_TEST_COMMAND, Workspace, WorkspaceViolation
+
+
+def change(path: str, content: str = "updated\n") -> FileChange:
+    return FileChange(path=path, new_content=content, reason="test change")
+
+
+def test_lists_and_reads_only_workspace_files(tmp_path: Path) -> None:
+    (tmp_path / "module.py").write_text("value = 1\n", encoding="utf-8")
+    workspace = Workspace(tmp_path)
+
+    assert workspace.list_files() == ["module.py"]
+    assert workspace.read_file("module.py") == "value = 1\n"
+
+
+def test_rejects_path_traversal(tmp_path: Path) -> None:
+    workspace = Workspace(tmp_path)
+
+    with pytest.raises(WorkspaceViolation, match="escapes"):
+        workspace.read_file("../secret.txt")
+
+
+def test_rejects_symlink_that_escapes_workspace(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (workspace_root / "link.txt").symlink_to(outside)
+
+    with pytest.raises(WorkspaceViolation, match="escapes"):
+        Workspace(workspace_root).read_file("link.txt")
+
+
+def test_does_not_expose_environment_files(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("API_KEY=secret\n", encoding="utf-8")
+    (tmp_path / "config.txt").symlink_to(tmp_path / ".env")
+    workspace = Workspace(tmp_path)
+
+    assert workspace.list_files() == []
+    with pytest.raises(WorkspaceViolation, match="not exposed"):
+        workspace.read_file(".env")
+    with pytest.raises(WorkspaceViolation, match="not exposed"):
+        workspace.read_file("config.txt")
+
+
+def test_requires_approval_before_writing(tmp_path: Path) -> None:
+    target = tmp_path / "module.py"
+    target.write_text("original\n", encoding="utf-8")
+    workspace = Workspace(tmp_path)
+
+    with pytest.raises(PermissionError, match="explicit human approval"):
+        workspace.apply_changes([change("module.py")], approved=False)
+
+    assert target.read_text(encoding="utf-8") == "original\n"
+
+
+def test_applies_an_approved_change(tmp_path: Path) -> None:
+    target = tmp_path / "module.py"
+    target.write_text("original\n", encoding="utf-8")
+    workspace = Workspace(tmp_path)
+
+    changed = workspace.apply_changes([change("module.py")], approved=True)
+
+    assert changed == ["module.py"]
+    assert target.read_text(encoding="utf-8") == "updated\n"
+
+
+def test_runs_only_the_predefined_pytest_command(tmp_path: Path) -> None:
+    (tmp_path / "test_example.py").write_text(
+        "def test_example():\n    assert 2 + 2 == 4\n", encoding="utf-8"
+    )
+
+    result = Workspace(tmp_path).run_tests()
+
+    assert result.command == list(ALLOWED_TEST_COMMAND)
+    assert result.command == [sys.executable, "-m", "pytest", "-q"]
+    assert result.passed
+
+
+def test_approved_fixture_fix_turns_red_tests_green(tmp_path: Path) -> None:
+    (tmp_path / "calculator.py").write_text(
+        "def add(left, right):\n    return left - right\n", encoding="utf-8"
+    )
+    (tmp_path / "test_calculator.py").write_text(
+        "from calculator import add\n\ndef test_add():\n    assert add(2, 3) == 5\n",
+        encoding="utf-8",
+    )
+    workspace = Workspace(tmp_path)
+
+    assert not workspace.run_tests().passed
+    workspace.apply_changes(
+        [
+            change(
+                "calculator.py",
+                "def add(left, right):\n    return left + right\n",
+            )
+        ],
+        approved=True,
+    )
+
+    assert workspace.run_tests().passed
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", " YES "])
+def test_accepts_explicit_approval(answer: str) -> None:
+    assert approved_by_human(answer)
+
+
+@pytest.mark.parametrize("answer", ["", "n", "no", "sure", "ok"])
+def test_rejects_ambiguous_approval(answer: str) -> None:
+    assert not approved_by_human(answer)

--- a/starter_ai_agents/coding_harness_starter/tests/test_workspace.py
+++ b/starter_ai_agents/coding_harness_starter/tests/test_workspace.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-from main import approved_by_human
+from main import approved_by_human, preview_changes
 from models import FileChange
 from workspace import ALLOWED_TEST_COMMAND, Workspace, WorkspaceViolation
 
 
 def change(path: str, content: str = "updated\n") -> FileChange:
+    """Build a small valid proposal for workspace tests."""
     return FileChange(path=path, new_content=content, reason="test change")
 
 
 def test_lists_and_reads_only_workspace_files(tmp_path: Path) -> None:
+    """Workspace inspection returns bounded relative paths and contents."""
     (tmp_path / "module.py").write_text("value = 1\n", encoding="utf-8")
     workspace = Workspace(tmp_path)
 
@@ -23,6 +26,7 @@ def test_lists_and_reads_only_workspace_files(tmp_path: Path) -> None:
 
 
 def test_rejects_path_traversal(tmp_path: Path) -> None:
+    """Parent traversal cannot escape the configured root."""
     workspace = Workspace(tmp_path)
 
     with pytest.raises(WorkspaceViolation, match="escapes"):
@@ -30,6 +34,7 @@ def test_rejects_path_traversal(tmp_path: Path) -> None:
 
 
 def test_rejects_symlink_that_escapes_workspace(tmp_path: Path) -> None:
+    """A symlink cannot provide an alias to an external file."""
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     outside = tmp_path / "secret.txt"
@@ -41,6 +46,7 @@ def test_rejects_symlink_that_escapes_workspace(tmp_path: Path) -> None:
 
 
 def test_does_not_expose_environment_files(tmp_path: Path) -> None:
+    """Environment files stay hidden even behind an in-workspace symlink."""
     (tmp_path / ".env").write_text("API_KEY=secret\n", encoding="utf-8")
     (tmp_path / "config.txt").symlink_to(tmp_path / ".env")
     workspace = Workspace(tmp_path)
@@ -53,6 +59,7 @@ def test_does_not_expose_environment_files(tmp_path: Path) -> None:
 
 
 def test_requires_approval_before_writing(tmp_path: Path) -> None:
+    """The workspace rejects writes without an affirmative human gate."""
     target = tmp_path / "module.py"
     target.write_text("original\n", encoding="utf-8")
     workspace = Workspace(tmp_path)
@@ -64,6 +71,7 @@ def test_requires_approval_before_writing(tmp_path: Path) -> None:
 
 
 def test_applies_an_approved_change(tmp_path: Path) -> None:
+    """An approved proposal may update a file within the workspace."""
     target = tmp_path / "module.py"
     target.write_text("original\n", encoding="utf-8")
     workspace = Workspace(tmp_path)
@@ -74,7 +82,58 @@ def test_applies_an_approved_change(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "updated\n"
 
 
+def test_rolls_back_an_incomplete_multi_file_change(tmp_path: Path) -> None:
+    """A later invalid target restores files changed earlier in the batch."""
+    first = tmp_path / "first.py"
+    first.write_text("original\n", encoding="utf-8")
+    (tmp_path / "not_a_file").mkdir()
+    workspace = Workspace(tmp_path)
+
+    with pytest.raises(WorkspaceViolation, match="not a file"):
+        workspace.apply_changes(
+            [change("first.py"), change("not_a_file")], approved=True
+        )
+
+    assert first.read_text(encoding="utf-8") == "original\n"
+
+
+def test_rejects_non_utf8_files(tmp_path: Path) -> None:
+    """Binary data becomes a recoverable workspace violation."""
+    (tmp_path / "binary.dat").write_bytes(b"\xff\xfe")
+
+    with pytest.raises(WorkspaceViolation, match="not valid UTF-8"):
+        Workspace(tmp_path).read_file("binary.dat")
+
+
+def test_diff_preview_enforces_existing_file_size(tmp_path: Path, monkeypatch) -> None:
+    """Diff rendering does not read an oversized existing file."""
+    (tmp_path / "large.py").write_text("12345", encoding="utf-8")
+    monkeypatch.setattr("workspace.MAX_FILE_SIZE", 4)
+
+    with pytest.raises(WorkspaceViolation, match="read limit"):
+        Workspace(tmp_path).preview_diff(change("large.py", "ok"))
+
+
+def test_diff_preview_enforces_proposed_file_size(tmp_path: Path, monkeypatch) -> None:
+    """Diff rendering rejects oversized model output before splitting it."""
+    monkeypatch.setattr("workspace.MAX_FILE_SIZE", 4)
+
+    with pytest.raises(WorkspaceViolation, match="Proposed content"):
+        Workspace(tmp_path).preview_diff(change("new.py", "12345"))
+
+
+def test_invalid_preview_emits_a_structured_summary(tmp_path: Path, capsys) -> None:
+    """An unsafe proposal is rejected before the approval prompt."""
+    rendered = preview_changes(Workspace(tmp_path), [change("../escape.py")])
+
+    assert not rendered
+    output = capsys.readouterr().out
+    assert '"status": "invalid_proposal"' in output
+    assert '"error":' in output
+
+
 def test_runs_only_the_predefined_pytest_command(tmp_path: Path) -> None:
+    """Test execution uses the immutable argument list and no shell."""
     (tmp_path / "test_example.py").write_text(
         "def test_example():\n    assert 2 + 2 == 4\n", encoding="utf-8"
     )
@@ -86,7 +145,30 @@ def test_runs_only_the_predefined_pytest_command(tmp_path: Path) -> None:
     assert result.passed
 
 
+def test_test_timeout_returns_a_structured_failure(tmp_path: Path, monkeypatch) -> None:
+    """A pytest timeout is represented by a failed TestResult."""
+
+    def raise_timeout(*args, **kwargs):
+        """Simulate a child process that exceeds its deadline."""
+        raise subprocess.TimeoutExpired(
+            cmd=list(ALLOWED_TEST_COMMAND),
+            timeout=1,
+            output="partial output",
+            stderr="partial error",
+        )
+
+    monkeypatch.setattr(subprocess, "run", raise_timeout)
+
+    result = Workspace(tmp_path).run_tests(timeout_seconds=1)
+
+    assert result.returncode == 124
+    assert result.stdout == "partial output"
+    assert "partial error" in result.stderr
+    assert "timed out after 1 seconds" in result.stderr
+
+
 def test_approved_fixture_fix_turns_red_tests_green(tmp_path: Path) -> None:
+    """The approved edit and predefined command complete a red-green loop."""
     (tmp_path / "calculator.py").write_text(
         "def add(left, right):\n    return left - right\n", encoding="utf-8"
     )
@@ -112,9 +194,11 @@ def test_approved_fixture_fix_turns_red_tests_green(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("answer", ["y", "Y", "yes", " YES "])
 def test_accepts_explicit_approval(answer: str) -> None:
+    """Only clear affirmative spellings open the write gate."""
     assert approved_by_human(answer)
 
 
 @pytest.mark.parametrize("answer", ["", "n", "no", "sure", "ok"])
 def test_rejects_ambiguous_approval(answer: str) -> None:
+    """Empty, negative, and ambiguous responses keep the gate closed."""
     assert not approved_by_human(answer)

--- a/starter_ai_agents/coding_harness_starter/tools.py
+++ b/starter_ai_agents/coding_harness_starter/tools.py
@@ -1,0 +1,29 @@
+"""Read-only PydanticAI tools for repository inspection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai import RunContext
+
+from workspace import Workspace, WorkspaceViolation
+
+
+@dataclass
+class AgentDependencies:
+    """Runtime dependencies available to the agent's tools."""
+
+    workspace: Workspace
+
+
+def list_files(ctx: RunContext[AgentDependencies]) -> list[str]:
+    """List all files under the configured workspace."""
+    return ctx.deps.workspace.list_files()
+
+
+def read_file(ctx: RunContext[AgentDependencies], path: str) -> str:
+    """Read one file using a path relative to the configured workspace."""
+    try:
+        return ctx.deps.workspace.read_file(path)
+    except WorkspaceViolation as exc:
+        return f"ERROR: {exc}"

--- a/starter_ai_agents/coding_harness_starter/workspace.py
+++ b/starter_ai_agents/coding_harness_starter/workspace.py
@@ -101,11 +101,8 @@ class Workspace:
             )
         )
 
-    def apply_changes(self, changes: list[FileChange], *, approved: bool) -> list[str]:
-        """Apply changes only after an explicit approval decision."""
-        if not approved:
-            raise PermissionError("File writes require explicit human approval.")
-
+    def validate_changes(self, changes: list[FileChange]) -> list[tuple[FileChange, Path]]:
+        """Validate a complete proposal batch without mutating the workspace."""
         resolved: list[tuple[FileChange, Path]] = []
         seen: set[Path] = set()
         for change in changes:
@@ -116,16 +113,31 @@ class Workspace:
                 )
             if path in seen:
                 raise WorkspaceViolation(f"Duplicate change for {change.path!r}")
+            if path.exists() and not path.is_file():
+                raise WorkspaceViolation(f"Target is not a file: {change.path!r}")
             seen.add(path)
             resolved.append((change, path))
+        return resolved
 
+    def apply_changes(self, changes: list[FileChange], *, approved: bool) -> list[str]:
+        """Apply changes only after an explicit approval decision."""
+        if not approved:
+            raise PermissionError("File writes require explicit human approval.")
+
+        resolved = self.validate_changes(changes)
+
+        created_directories: list[Path] = []
         originals: dict[Path, bytes | None] = {}
         changed_files = []
         try:
             for change, path in resolved:
-                if path.exists() and not path.is_file():
-                    raise WorkspaceViolation(f"Target is not a file: {change.path!r}")
                 originals[path] = path.read_bytes() if path.is_file() else None
+                missing_parents: list[Path] = []
+                parent = path.parent
+                while parent != self.root and not parent.exists():
+                    missing_parents.append(parent)
+                    parent = parent.parent
+                created_directories.extend(reversed(missing_parents))
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(change.new_content, encoding="utf-8")
                 changed_files.append(change.path)
@@ -135,6 +147,11 @@ class Workspace:
                     path.unlink(missing_ok=True)
                 else:
                     path.write_bytes(original)
+            for directory in reversed(created_directories):
+                try:
+                    directory.rmdir()
+                except OSError:
+                    pass
             if isinstance(exc, WorkspaceViolation):
                 raise
             raise WorkspaceViolation(

--- a/starter_ai_agents/coding_harness_starter/workspace.py
+++ b/starter_ai_agents/coding_harness_starter/workspace.py
@@ -1,0 +1,135 @@
+"""Constrained filesystem and test runner for the coding harness."""
+
+from __future__ import annotations
+
+import difflib
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from models import FileChange, TestResult
+
+IGNORED_PARTS = {".env", ".git", ".pytest_cache", ".venv", "__pycache__"}
+MAX_FILE_SIZE = 50_000
+ALLOWED_TEST_COMMAND = (sys.executable, "-m", "pytest", "-q")
+
+
+class WorkspaceViolation(ValueError):
+    """Raised when an operation would escape the configured workspace."""
+
+
+class Workspace:
+    """Expose only bounded repository operations to the harness."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve(strict=True)
+        if not self.root.is_dir():
+            raise WorkspaceViolation(f"Workspace is not a directory: {self.root}")
+
+    def _resolve(self, relative_path: str) -> Path:
+        path = Path(relative_path)
+        if path.is_absolute():
+            raise WorkspaceViolation("Absolute paths are not allowed.")
+
+        resolved = (self.root / path).resolve(strict=False)
+        try:
+            resolved_relative = resolved.relative_to(self.root)
+        except ValueError as exc:
+            raise WorkspaceViolation(
+                f"Path escapes the configured workspace: {relative_path!r}"
+            ) from exc
+        if any(
+            part in IGNORED_PARTS for part in (*path.parts, *resolved_relative.parts)
+        ):
+            raise WorkspaceViolation(
+                f"Path is not exposed to the agent: {relative_path!r}"
+            )
+        return resolved
+
+    def list_files(self) -> list[str]:
+        """Return readable files relative to the workspace root."""
+        files = []
+        for path in sorted(self.root.rglob("*")):
+            relative = path.relative_to(self.root)
+            if any(part in IGNORED_PARTS for part in relative.parts):
+                continue
+            if path.is_file():
+                try:
+                    self._resolve(relative.as_posix())
+                except WorkspaceViolation:
+                    continue
+                files.append(relative.as_posix())
+        return files
+
+    def read_file(self, relative_path: str) -> str:
+        """Read one UTF-8 file after enforcing the workspace boundary."""
+        path = self._resolve(relative_path)
+        if not path.is_file():
+            raise WorkspaceViolation(f"File does not exist: {relative_path!r}")
+        if path.stat().st_size > MAX_FILE_SIZE:
+            raise WorkspaceViolation(
+                f"File exceeds the {MAX_FILE_SIZE}-byte read limit: {relative_path!r}"
+            )
+        return path.read_text(encoding="utf-8")
+
+    def preview_diff(self, change: FileChange) -> str:
+        """Build a unified diff without mutating the workspace."""
+        path = self._resolve(change.path)
+        current = path.read_text(encoding="utf-8") if path.is_file() else ""
+        return "".join(
+            difflib.unified_diff(
+                current.splitlines(keepends=True),
+                change.new_content.splitlines(keepends=True),
+                fromfile=f"a/{change.path}",
+                tofile=f"b/{change.path}",
+            )
+        )
+
+    def apply_changes(self, changes: list[FileChange], *, approved: bool) -> list[str]:
+        """Apply changes only after an explicit approval decision."""
+        if not approved:
+            raise PermissionError("File writes require explicit human approval.")
+
+        resolved: list[tuple[FileChange, Path]] = []
+        seen: set[Path] = set()
+        for change in changes:
+            path = self._resolve(change.path)
+            if len(change.new_content.encode("utf-8")) > MAX_FILE_SIZE:
+                raise WorkspaceViolation(
+                    f"Proposed content exceeds {MAX_FILE_SIZE} bytes: {change.path!r}"
+                )
+            if path in seen:
+                raise WorkspaceViolation(f"Duplicate change for {change.path!r}")
+            seen.add(path)
+            resolved.append((change, path))
+
+        changed_files = []
+        for change, path in resolved:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(change.new_content, encoding="utf-8")
+            changed_files.append(change.path)
+        return changed_files
+
+    def run_tests(self, *, timeout_seconds: int = 30) -> TestResult:
+        """Run the single predefined pytest command without a shell."""
+        with tempfile.TemporaryDirectory(prefix="coding-harness-pycache-") as cache:
+            env = os.environ.copy()
+            env["PYTHONPYCACHEPREFIX"] = cache
+            completed = subprocess.run(
+                list(ALLOWED_TEST_COMMAND),
+                cwd=self.root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+                shell=False,
+                env=env,
+            )
+        return TestResult(
+            command=list(ALLOWED_TEST_COMMAND),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )

--- a/starter_ai_agents/coding_harness_starter/workspace.py
+++ b/starter_ai_agents/coding_harness_starter/workspace.py
@@ -68,16 +68,30 @@ class Workspace:
         path = self._resolve(relative_path)
         if not path.is_file():
             raise WorkspaceViolation(f"File does not exist: {relative_path!r}")
+        return self._read_bounded_text(path, relative_path)
+
+    @staticmethod
+    def _read_bounded_text(path: Path, relative_path: str) -> str:
+        """Read a bounded UTF-8 file and convert decoding errors."""
         if path.stat().st_size > MAX_FILE_SIZE:
             raise WorkspaceViolation(
                 f"File exceeds the {MAX_FILE_SIZE}-byte read limit: {relative_path!r}"
             )
-        return path.read_text(encoding="utf-8")
+        try:
+            return path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise WorkspaceViolation(
+                f"File is not valid UTF-8 text: {relative_path!r}"
+            ) from exc
 
     def preview_diff(self, change: FileChange) -> str:
         """Build a unified diff without mutating the workspace."""
         path = self._resolve(change.path)
-        current = path.read_text(encoding="utf-8") if path.is_file() else ""
+        if len(change.new_content.encode("utf-8")) > MAX_FILE_SIZE:
+            raise WorkspaceViolation(
+                f"Proposed content exceeds {MAX_FILE_SIZE} bytes: {change.path!r}"
+            )
+        current = self._read_bounded_text(path, change.path) if path.is_file() else ""
         return "".join(
             difflib.unified_diff(
                 current.splitlines(keepends=True),
@@ -105,11 +119,27 @@ class Workspace:
             seen.add(path)
             resolved.append((change, path))
 
+        originals: dict[Path, bytes | None] = {}
         changed_files = []
-        for change, path in resolved:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(change.new_content, encoding="utf-8")
-            changed_files.append(change.path)
+        try:
+            for change, path in resolved:
+                if path.exists() and not path.is_file():
+                    raise WorkspaceViolation(f"Target is not a file: {change.path!r}")
+                originals[path] = path.read_bytes() if path.is_file() else None
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(change.new_content, encoding="utf-8")
+                changed_files.append(change.path)
+        except (OSError, WorkspaceViolation) as exc:
+            for path, original in reversed(originals.items()):
+                if original is None:
+                    path.unlink(missing_ok=True)
+                else:
+                    path.write_bytes(original)
+            if isinstance(exc, WorkspaceViolation):
+                raise
+            raise WorkspaceViolation(
+                f"Could not apply the approved changes: {exc}"
+            ) from exc
         return changed_files
 
     def run_tests(self, *, timeout_seconds: int = 30) -> TestResult:
@@ -117,16 +147,32 @@ class Workspace:
         with tempfile.TemporaryDirectory(prefix="coding-harness-pycache-") as cache:
             env = os.environ.copy()
             env["PYTHONPYCACHEPREFIX"] = cache
-            completed = subprocess.run(
-                list(ALLOWED_TEST_COMMAND),
-                cwd=self.root,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                check=False,
-                shell=False,
-                env=env,
-            )
+            try:
+                completed = subprocess.run(
+                    list(ALLOWED_TEST_COMMAND),
+                    cwd=self.root,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_seconds,
+                    check=False,
+                    shell=False,
+                    env=env,
+                )
+            except subprocess.TimeoutExpired as exc:
+                stdout = exc.stdout or ""
+                stderr = exc.stderr or ""
+                if isinstance(stdout, bytes):
+                    stdout = stdout.decode(errors="replace")
+                if isinstance(stderr, bytes):
+                    stderr = stderr.decode(errors="replace")
+                timeout_message = f"Tests timed out after {timeout_seconds} seconds."
+                stderr = f"{stderr}\n{timeout_message}".strip()
+                return TestResult(
+                    command=list(ALLOWED_TEST_COMMAND),
+                    returncode=124,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
         return TestResult(
             command=list(ALLOWED_TEST_COMMAND),
             returncode=completed.returncode,


### PR DESCRIPTION
## Summary
- add a compact PydanticAI coding loop with read-only repository tools and structured patch proposals
- require explicit human approval before applying any file change
- enforce workspace path boundaries and run one allowlisted pytest command without a shell
- include a tiny broken calculator fixture, offline agent coverage, safety tests, and documentation
- add the starter to the root catalog

## Safety boundaries
- rejects absolute paths, traversal, and symlinks that escape the workspace
- hides environment, Git, virtual-environment, and cache paths from agent tools
- gives the model no write or shell tool
- validates every path before applying an approved change
- runs a constant pytest argument list with `shell=False`

## Testing
- `uv run --extra dev pytest tests -q` — 18 passed
- `uvx ruff check .`
- `uvx ruff format --check .`

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Coding Harness Starter project for AI-assisted workspace inspection and structured change proposals.
  * Supports patch previews, human approval, controlled file updates, and fixed test execution.
  * Includes workspace boundary protections, safe file handling, rollback after failed updates, and consistent run summaries.
  * Provides a sample calculator repair workflow.

* **Documentation**
  * Added setup, usage, configuration, workflow, and safety guidance.

* **Tests**
  * Added coverage for proposals, protections, approvals, rollbacks, and test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->