### PR TITLE
fix(doc_mcp): strip the .git suffix by suffix, not by character set

### DIFF
--- a/mcp_ai_agents/doc_mcp/src/github/parser.py
+++ b/mcp_ai_agents/doc_mcp/src/github/parser.py
@@ -40,7 +40,7 @@ def parse_github_url(url: str) -> Tuple[str, str]:
         if match:
             owner, repo = match.groups()
             # Clean up repo name (remove .git suffix if present)
-            repo = repo.rstrip(".git")
+            repo = repo.removesuffix(".git")
             return owner, repo
 
     raise GitHubError(f"Invalid GitHub URL format: {url}")


### PR DESCRIPTION
## Problem

In `mcp_ai_agents/doc_mcp/src/github/parser.py`, `parse_github_url()` cleans the repository name with

```python
# Clean up repo name (remove .git suffix if present)
repo = repo.rstrip(".git")
```

`str.rstrip` takes a **character set**, not a suffix, so this removes every trailing `.`, `g`, `i` and `t` — whether or not a `.git` suffix was ever there. Any repository whose name ends in one of those letters is silently truncated, and the resulting GitHub API call 404s.

## Fix

`repo.removesuffix(".git")` — removes the suffix when present, leaves the name untouched otherwise. One line, no behaviour change for names that do end in `.git`.

## Verification

`parse_github_url` was extracted from the file with `ast.get_source_segment` (no hand-copying) and run before and after the change:

| url | unpatched | patched |
|---|---|---|
| `.../open-webui/open-webui` | `open-webui/open-webu` ❌ | `open-webui/open-webui` ✅ |
| `.../streamlit/streamlit` | `streamlit/streaml` ❌ | `streamlit/streamlit` ✅ |
| `.../lobehub/lobe-chat` | `lobehub/lobe-cha` ❌ | `lobehub/lobe-chat` ✅ |
| `.../mckaywrigley/chatbot-ui` | `mckaywrigley/chatbot-u` ❌ | `mckaywrigley/chatbot-ui` ✅ |
| `.../microsoft/git` | `microsoft/` ❌ | `microsoft/git` ✅ |
| `.../langchain-ai/langchain.git` | `langchain-ai/langchain` | `langchain-ai/langchain` |
| `.../psf/requests.git` | `psf/requests` | `psf/requests` |
| `.../Arindam200/awesome-ai-apps` | `Arindam200/awesome-ai-apps` | `Arindam200/awesome-ai-apps` |
| `.../pytorch/pytorch` | `pytorch/pytorch` | `pytorch/pytorch` |
| `openai/openai-python` (shorthand) | `openai/openai-python` | `openai/openai-python` |

The `.git`-suffixed and unaffected cases are identical before and after; only the truncated ones change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub repository URL parsing to preserve valid repository names ending in characters such as “g” or “t”.
  * Repository names ending in “.git” continue to be cleaned up correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->